### PR TITLE
入力文字の処理変更

### DIFF
--- a/app/controllers/auth/login_handler.go
+++ b/app/controllers/auth/login_handler.go
@@ -6,7 +6,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
-	"html"
 	"log"
 	"net/http"
 	"net/url"
@@ -28,14 +27,14 @@ func Login(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	//メールアドレスをリクエストから取得
-	email := html.EscapeString(req.FormValue("email"))
+	email := req.FormValue("email")
 	if email == "" {
 		msg := url.QueryEscape("メールアドレスを入力してください。")
 		http.Redirect(w, req, "/register/?msg="+msg, http.StatusSeeOther)
 		return
 	}
 	//パスワードをリクエストから取得
-	password := html.EscapeString(req.FormValue("password"))
+	password := req.FormValue("password")
 	if password == "" {
 		msg := url.QueryEscape("パスワードを入力してください。")
 		http.Redirect(w, req, "/register/?msg="+msg, http.StatusSeeOther)

--- a/app/controllers/auth/register_handler.go
+++ b/app/controllers/auth/register_handler.go
@@ -8,7 +8,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
-	"html"
 	"log"
 	"net/http"
 	"net/smtp"
@@ -25,21 +24,21 @@ func Register(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	//ユーザー名をリクエストから取得
-	userName := html.EscapeString(req.FormValue("username"))
+	userName := req.FormValue("username")
 	if userName == "" {
 		msg := url.QueryEscape("ユーザー名を入力してください。")
 		http.Redirect(w, req, "/register_form/?msg="+msg, http.StatusSeeOther)
 		return
 	}
 	//メールアドレスをリクエストから取得
-	email := html.EscapeString(req.FormValue("email"))
+	email := req.FormValue("email")
 	if email == "" {
 		msg := url.QueryEscape("メールアドレスを入力してください。")
 		http.Redirect(w, req, "/register_form/?msg="+msg, http.StatusSeeOther)
 		return
 	}
 	//パスワードをリクエストから取得
-	password := html.EscapeString(req.FormValue("password"))
+	password := req.FormValue("password")
 	if password == "" {
 		msg := url.QueryEscape("パスワードを入力してください。")
 		http.Redirect(w, req, "/register_form/?msg="+msg, http.StatusSeeOther)

--- a/app/controllers/routes/multi_search.go
+++ b/app/controllers/routes/multi_search.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"html"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -38,8 +37,8 @@ func SaveRoutes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if strings.Contains(reqFields.Title, ".") {
-		http.Error(w, "ルート名に.(ドット)は使用できません。", http.StatusBadRequest)
+	if strings.ContainsAny(reqFields.Title, ".$") {
+		http.Error(w, "ルート名にご使用いただけない文字が含まれています。", http.StatusBadRequest)
 		return
 	}
 
@@ -74,7 +73,7 @@ func SaveRoutes(w http.ResponseWriter, req *http.Request) {
 	//users collectionのmulti_route_titlesフィールドにルート名と作成時刻を追加($set)する。作成時刻はルート名取得時に作瀬時刻でソートするため
 	userDoc := bson.D{{"_id", userID}}
 	now := time.Now().UTC()                                                                //MongoDBでは、timeはUTC表記で扱われ、タイムゾーン情報は入れられない
-	updateField := bson.M{"multi_route_titles." + html.EscapeString(reqFields.Title): now} //nested fieldsは.(ドット表記)で繋いで書く
+	updateField := bson.M{"multi_route_titles." + reqFields.Title: now} //nested fieldsは.(ドット表記)で繋いで書く
 	err = dbhandler.UpdateOne("googroutes", "users", "$set", userDoc, updateField)
 
 	//routes collectionに保存

--- a/app/dev_memo.txt
+++ b/app/dev_memo.txt
@@ -23,3 +23,11 @@ toggleボタンなどはjQueryで自分で実装する必要あり。
 
 　http.HandleFuncでクエリーパラメータを使う場合、URIパスの最後に/を入れないと、クエリー部は無視されて
 意図したように動作しないため注意
+
+  MongoDBでフィールドをuniqueにする場合、indexを作成する。
+(indexを作成する手順)
+MongoDBを実行中のマシンで
+$mongo -u < ユーザー名> -p
+//MongoDb shell
+$use googroutes;
+$db.users.createIndex({"email":1},{unique:true})

--- a/app/templates/multi_search/multi_search.html
+++ b/app/templates/multi_search/multi_search.html
@@ -30,7 +30,7 @@
         <input type="button" class="mt-3 mb-3 btn-primary" id="add-route" value="次のルートを追加"><br>
         <hr>
         <span class="ml-2" style="color: black">ルートの保存:</span>
-        <input type="text" class="mt-3" id="route-name" style="width: 350px" placeholder="保存するタイトルを入力"><br>
+        <input type="text" class="mt-3" id="route-name" style="width: 350px" placeholder="保存するタイトルを入力(.,$以外の文字)"><br>
         <input type="button" class="mt-1 btn-success" id="save-route" value="ルートを保存">
     </div>
 </div>

--- a/app/templates/multi_search/multi_search.js
+++ b/app/templates/multi_search/multi_search.js
@@ -22,6 +22,10 @@ const multiSearchReq = {
 $(function () {
   $("#save-route").click(function () {
     multiSearchReq["title"] = document.getElementById("route-name").value;
+    if (/[\.\$]/.test(document.getElementById("route-name").value)) {
+      window.alert(".または$はルート名に使用できません。");
+      return
+    }
     // 多重送信を防ぐため通信完了までボタンをdisableにする
     var button = $(this);
     button.attr("disabled", true);


### PR DESCRIPTION
1: MongoDBの仕様上、.$がフィールド名として使えないので、入力制限を追加
2: golangのtemplateでDBから取得した文字列を表示する際、DBにエスケープした状態で保存するとエスケープした文字が常時されてしまうので、保存時エスケープしないで保存するよう変更
3: MongoDBでフィールド名をuniqueにするため、indexを追加する手順をメモに追加 