### PR TITLE
Cookieの修正

### DIFF
--- a/app/controllers/auth/login_handler.go
+++ b/app/controllers/auth/login_handler.go
@@ -88,6 +88,7 @@ func Login(w http.ResponseWriter, req *http.Request) {
 	c := &http.Cookie{
 		Name:  "sessionId",
 		Value: signedStr,
+		Path: "/",
 	}
 	http.SetCookie(w, c)
 	http.Redirect(w, req, "/", http.StatusSeeOther)

--- a/app/dev_memo.txt
+++ b/app/dev_memo.txt
@@ -37,3 +37,8 @@ $db.users.createIndex({"email":1},{unique:true})
 
 　multi_routes_show.html内でtemplate実行時にJSONが入った変数routeInfoをmulti_route_show.jsより上部で宣言することで、
 multi_route_show.js内でroutesInfoが使用可能になる。
+
+　CookieのPathを指定しないと、ConfirmRegisterでリダイレクトしたときに、Cookieが設定されない。
+Loginの時はCookieが設定されていて、違いはリクエストメソッドがGETかPOSTであることのみ。おそらく、
+GETで/confirm_emailにGETでアクセスして、リダイレクトだと、最初のレスポンス先のパス(/confirm_email)にCookie
+が設定されて、リダイレクトで(/)にアクセスする時、異なるドメインとして扱われてしまうのではないかと思われる。


### PR DESCRIPTION
1: GETメソッドアクセスに対し、CookieをセットしてリダイレクトするとCookieが消滅する問題があったので、それを防ぐため、CookieのPathをホーム(/)に設定