### PR TITLE
ルート編集保存時のバグ修正

### DIFF
--- a/app/controllers/routes/multi_search.go
+++ b/app/controllers/routes/multi_search.go
@@ -171,8 +171,9 @@ func UpdateRoute(w http.ResponseWriter, req *http.Request) {
 
 	} else {
 		//元のルート名を削除
-		deleteField := bson.M{"multi_route_titles": reqFields.PreviousTitle}
+		deleteField := bson.M{"multi_route_titles."+reqFields.PreviousTitle:""}
 		//documentではなく、document内のフィールドを削除する場合、Deleteではなく、Update operatorの$unsetを使って削除する
+		//公式ドキュメントURL: https://docs.mongodb.com/manual/reference/operator/update/unset/
 		err = dbhandler.UpdateOne("googroutes", "users", "$unset", userDoc, deleteField)
 		//新しいルート名とタイムスタンプを追加
 		updateField := bson.M{"multi_route_titles." + reqFields.Title: now} //nested fieldsは.(ドット表記)で繋いで書く

--- a/app/dev_memo.txt
+++ b/app/dev_memo.txt
@@ -48,3 +48,9 @@ GETで/confirm_emailにGETでアクセスして、リダイレクトだと、最
 よくない。次にリダイレクトでクエリーパラメータを使ってmsgを追加しようとしたが、GETとPOSTのURIが同じだと、
 リダイレクト時にクエリー部が自動で省略されてしまうため、パラメータを渡せなかった。
 解決策として、GETとPOSTのURIを別のまま、リダイレクトすればクエリーパラメータを渡すことができた。
+
+  MongoDBのdocument内でフィールドの一部を削除する場合、
+deleteField := bson.M{"<フィールド名>":""} ←目的のフィールド名を設定し、値を""にする。
+そして、$unsetを使うことで、１つだけ削除できる。
+dbhandler.UpdateOne("googroutes", "users", "$unset", userDoc, deleteField)
+公式ドキュメントURL: https://docs.mongodb.com/manual/reference/operator/update/unset/


### PR DESCRIPTION
1: MongoDBのフィールド指定方法が間違っており、ルート編集保存時に他のルート名が全て削除されてしまうようになっていたので修正