### PR TITLE
保存したルートを削除できるよう機能追加

### DIFF
--- a/app/controllers/multiroute/delete.go
+++ b/app/controllers/multiroute/delete.go
@@ -1,0 +1,59 @@
+package multiroute
+
+import (
+	"app/dbhandler"
+	"app/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"log"
+	"net/http"
+)
+
+func DeleteRoute(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		msg = "HTTPメソッドが不正です。"
+		http.Redirect(w, req, "/mypage/show_routes/?msg="+msg, http.StatusSeeOther)
+		return
+	}
+
+	//Auth middlewareからuserIDを取得
+	user, ok := req.Context().Value("user").(model.UserData)
+	if !ok {
+		msg = "エラーが発生しました。もう一度操作を行ってください。"
+		http.Redirect(w, req, "/mypage/show_routes/?msg="+msg, http.StatusSeeOther)
+		log.Printf("Error while getting userID from reuest's context: %v", ok)
+		return
+	}
+	userID := user.ID
+
+	routeTitle := req.FormValue("title")
+
+	//削除するルートのユーザー
+	userDoc := bson.M{"_id": userID}
+
+	//「元のルート名をuser documentから削除」
+	deleteField := bson.M{"multi_route_titles." + routeTitle: ""}
+	//documentではなく、document内のフィールドを削除する場合、Deleteではなく、Update operatorの$unsetを使って削除する
+	//公式ドキュメントURL: https://docs.mongodb.com/manual/reference/operator/update/unset/
+	err := dbhandler.UpdateOne("googroutes", "users", "$unset", userDoc, deleteField)
+	if err != nil {
+		msg = "エラ-が発生しました。もう一度操作をしなおしてください。"
+		http.Redirect(w, req, "/mypage/show_routes/?msg="+msg, http.StatusSeeOther)
+		log.Printf("Error while deleting %v from multi_route_titles: %v", routeTitle, err)
+		return
+	}
+
+	////routes collectionから削除 エラー解析に使うかもしれないので、削除せずに残しておく
+	//routeDoc := bson.D{{"title", routeTitle}, {"user_id", userID}}
+	//err = dbhandler.Delete("googroutes", "routes", routeDoc)
+	//if err != nil {
+	//	msg = "エラ-が発生しました。もう一度操作をしなおしてください。"
+	//	http.Redirect(w, req, "/mypage/show_routes/?msg="+msg, http.StatusSeeOther)
+	//	log.Printf("Error while deleting route %v: %v",routeTitle, err)
+	//	return
+	//}
+
+	//レスポンス作成
+	success := "ルート「" + routeTitle + "」を削除しました。"
+	http.Redirect(w, req, "/mypage/show_routes/?success="+success, http.StatusSeeOther)
+	log.Printf("Route [%v] was deleted", routeTitle)
+}

--- a/app/controllers/multiroute/delete.go
+++ b/app/controllers/multiroute/delete.go
@@ -55,5 +55,5 @@ func DeleteRoute(w http.ResponseWriter, req *http.Request) {
 	//レスポンス作成
 	success := "ルート「" + routeTitle + "」を削除しました。"
 	http.Redirect(w, req, "/mypage/show_routes/?success="+success, http.StatusSeeOther)
-	log.Printf("Route [%v] was deleted", routeTitle)
+	log.Printf("User [%v] deleted route [%v]", user.UserName, routeTitle)
 }

--- a/app/controllers/multiroute/update_route.go
+++ b/app/controllers/multiroute/update_route.go
@@ -47,7 +47,7 @@ func UpdateRoute(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if err != nil {
-		msg := "エラ〜が発生しました。もう一度操作をしなおしてください。"
+		msg = "エラーが発生しました。もう一度操作をしなおしてください。"
 		http.Error(w, msg, http.StatusInternalServerError)
 		log.Printf("Error while saving multi route: %v", err)
 		return
@@ -61,7 +61,7 @@ func UpdateRoute(w http.ResponseWriter, req *http.Request) {
 	}
 	err = dbhandler.UpdateOne("googroutes", "routes", "$set", routeDoc, updateDoc)
 	if err != nil {
-		msg := "エラ〜が発生しました。もう一度操作をしなおしてください。"
+		msg = "エラーが発生しました。もう一度操作をしなおしてください。"
 		http.Error(w, msg, http.StatusInternalServerError)
 		log.Printf("Error while saving multi route: %v", err)
 		return
@@ -69,8 +69,8 @@ func UpdateRoute(w http.ResponseWriter, req *http.Request) {
 
 	//レスポンス作成
 	w.Header().Set("Content-Type", "application/json")
-	msg := ResponseMsg{Msg: "OK"}
-	respJson, err := json.Marshal(msg)
+	respMsg := ResponseMsg{Msg: "OK"}
+	respJson, err := json.Marshal(respMsg)
 	if err != nil {
 		log.Printf("Error while json marshaling: %v", err)
 	}

--- a/app/controllers/mypage/tpl_handler.go
+++ b/app/controllers/mypage/tpl_handler.go
@@ -17,18 +17,18 @@ func init() {
 }
 
 func ShowMypage(w http.ResponseWriter, req *http.Request) {
-	data,ok := req.Context().Value("data").(map[string]interface{})
+	data, ok := req.Context().Value("data").(map[string]interface{})
 	if !ok {
 		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
 		http.Redirect(w, req, "/?msg="+msg, http.StatusSeeOther)
-		log.Printf("Error while getting data from context: %v",ok)
+		log.Printf("Error while getting data from context: %v", ok)
 		return
 	}
-	user,ok := req.Context().Value("user").(model.UserData)
+	user, ok := req.Context().Value("user").(model.UserData)
 	if !ok {
 		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
 		http.Redirect(w, req, "/?msg="+msg, http.StatusSeeOther)
-		log.Printf("Error while getting user from context: %v",ok)
+		log.Printf("Error while getting user from context: %v", ok)
 		return
 	}
 	data["userName"] = user.UserName
@@ -36,18 +36,18 @@ func ShowMypage(w http.ResponseWriter, req *http.Request) {
 }
 
 func ShowAllRoutes(w http.ResponseWriter, req *http.Request) {
-	data,ok := req.Context().Value("data").(map[string]interface{})
+	data, ok := req.Context().Value("data").(map[string]interface{})
 	if !ok {
 		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
 		http.Redirect(w, req, "/mypage/?msg="+msg, http.StatusSeeOther)
-		log.Printf("Error while getting data from context: %v",ok)
+		log.Printf("Error while getting data from context: %v", ok)
 		return
 	}
-	user,ok := req.Context().Value("user").(model.UserData)
+	user, ok := req.Context().Value("user").(model.UserData)
 	if !ok {
 		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
 		http.Redirect(w, req, "/mypage/?msg="+msg, http.StatusSeeOther)
-		log.Printf("Error while getting user from context: %v",ok)
+		log.Printf("Error while getting user from context: %v", ok)
 		return
 	}
 	titleNames := RouteTitles(user.ID)
@@ -55,5 +55,18 @@ func ShowAllRoutes(w http.ResponseWriter, req *http.Request) {
 	data["titles"] = titleNames
 	//ルートの確認画面に飛べないエラーが発生した場合用
 	data["msg"] = req.URL.Query().Get("msg")
+	data["success"] = req.URL.Query().Get("success")
 	mypageTpl.ExecuteTemplate(w, "show_routes.html", data)
+}
+
+func ConfirmDelete(w http.ResponseWriter, req *http.Request) {
+	data, ok := req.Context().Value("data").(map[string]interface{})
+	if !ok {
+		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
+		http.Redirect(w, req, "/mypage/show_routes/?msg="+msg, http.StatusSeeOther)
+		log.Printf("Error while getting data from context: %v", ok)
+		return
+	}
+	data["title"] = req.FormValue("title")
+	mypageTpl.ExecuteTemplate(w, "confirm_delete.html", data)
 }

--- a/app/main.go
+++ b/app/main.go
@@ -39,13 +39,16 @@ func main() {
 	http.HandleFunc("/routes_save", middleware.Auth(middleware.SaveRoutesValidator(multiroute.SaveRoutes)))    //保存用エンドポイント
 	http.HandleFunc("/show_route/", middleware.Auth(multiroute.ShowAndEditRoutesTpl))                          //確認編集画面
 	http.HandleFunc("/update_route", middleware.Auth(middleware.UpdateRouteValidator(multiroute.UpdateRoute))) //編集用エンドポイント
+	http.HandleFunc("/delete_route", middleware.Auth(multiroute.DeleteRoute))                                  //削除用エンドポイント
+
 	//「同時検索」
-	http.HandleFunc("/simul_search", middleware.Auth(simulsearch.SimulSearchTpl)) //検索画面
-	http.HandleFunc("/do_simul_search", middleware.SimulSearchValidator(simulsearch.DoSimulSearch))                //検索実行用エンドポイント
+	http.HandleFunc("/simul_search", middleware.Auth(simulsearch.SimulSearchTpl))                   //検索画面
+	http.HandleFunc("/do_simul_search", middleware.SimulSearchValidator(simulsearch.DoSimulSearch)) //検索実行用エンドポイント
 
 	//「マイページ」
 	http.HandleFunc("/mypage", middleware.Auth(mypage.ShowMypage))                 //マイページ表示
 	http.HandleFunc("/mypage/show_routes/", middleware.Auth(mypage.ShowAllRoutes)) //保存したルート一覧
+	http.HandleFunc("/mypage/delete_route", middleware.Auth(mypage.ConfirmDelete)) //削除確認
 
 	//「ホーム」
 	http.HandleFunc("/", middleware.Auth(home))
@@ -57,7 +60,7 @@ func home(w http.ResponseWriter, req *http.Request) {
 	data, ok := req.Context().Value("data").(map[string]interface{})
 	if !ok {
 		log.Printf("Error whle gettibg data from context")
-		data = map[string]interface{}{"isLoggedIn":false}
+		data = map[string]interface{}{"isLoggedIn": false}
 	}
 	data["msg"] = req.URL.Query().Get("msg")
 	data["success"] = req.URL.Query().Get("success")

--- a/app/templates/mypage/confirm_delete.html
+++ b/app/templates/mypage/confirm_delete.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+
+    <title>保存済みルート一覧</title>
+</head>
+<body>
+{{ template "navbar" .}}
+<div class="mt-5 text-center">
+    <h3>削除の確認</h3>
+    <p>ルート{{.title}}を削除します。よろしいですか？</p>
+</div>
+<div class="d-flex">
+    <div class="mx-auto d-flex">
+        <form action="/delete_route" method="POST">
+            <button class="btn-danger mr-3" type="submit" name="title" value="{{.title}}">削除する</button>
+        </form>
+        <a href="show_routes.html">
+            <button class="btn-success">戻る</button>
+        </a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/app/templates/mypage/show_routes.html
+++ b/app/templates/mypage/show_routes.html
@@ -10,6 +10,9 @@
 {{ template "navbar" .}}
 {{if .msg}}
 <div class="py-2 d-flex" style="background-color: pink"><span class="mx-auto" style="color: brown">{{.msg}}</span></div>
+{{else if .success}}
+<div class="py-2 d-flex" style="background-color: lightblue"><span class="mx-auto"
+                                                                   style="color: green">{{.success}}</span></div>
 {{end}}
 <div class="mt-5 text-center">
     <h3>{{.userName}}さんが保存したルート</h3>
@@ -27,6 +30,10 @@
                     <a href="/show_route/?route_title={{$title}}">
                         <button class="btn-success" type="button">確認または編集</button>
                     </a>
+                    <hr>
+                    <form action="/mypage/delete_route" method="POST">
+                        <button class="btn-danger" type="submit" name="title" value="{{$title}}">削除する</button>
+                    </form>
                 </div><!-- card-body end .// -->
             </div><!-- card end.// -->
         </div>


### PR DESCRIPTION
1: 保存したルートを削除できるようボタンを追加
2: 削除時、DB内でuser document内のmulti_route_titlesのフィールド名だけ削除してユーザーからはアクセスできないようにし、route document自体は残しておく
3: 削除ボタンを押したら削除確認画面を開き、そこで削除ボタンが押されたら削除する