### PR TITLE
プロフィール編集のクライアント側のバリデーション機能作成

### DIFF
--- a/app/controllers/profile/tpl_handler.go
+++ b/app/controllers/profile/tpl_handler.go
@@ -73,6 +73,8 @@ func EditEmailForm(w http.ResponseWriter, req *http.Request) {
 	data["email"] = user.Email
 	msg = req.URL.Query().Get("msg")
 	data["msg"] = msg
+	newEmail := req.URL.Query().Get("newEmail")
+	data["newEmail"] = newEmail
 	profileTpl.ExecuteTemplate(w, "email_edit.html", data)
 }
 func EditPasswordForm(w http.ResponseWriter, req *http.Request) {

--- a/app/controllers/profile/update_email.go
+++ b/app/controllers/profile/update_email.go
@@ -37,7 +37,9 @@ func UpdateEmail(w http.ResponseWriter, req *http.Request) {
 	newEmail := req.FormValue("email")
 	if !isEmailValid(newEmail) {
 		msg = url.QueryEscape("メールアドレスに不備があります。")
-		http.Redirect(w, req, "/profile/email_edit_form/?msg="+msg, http.StatusSeeOther)
+		newEmail = url.QueryEscape(newEmail)
+		http.Redirect(w, req, "/profile/email_edit_form/?msg="+msg+"&newEmail="+newEmail, http.StatusSeeOther)
+		return
 	}
 
 	//メールアドレス認証用のトークンを作成

--- a/app/templates/profile/email_edit.html
+++ b/app/templates/profile/email_edit.html
@@ -2,6 +2,8 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="/templates/profile/email_edit.js"></script>
 
     <title>メールアドレスの編集</title>
 </head>
@@ -28,13 +30,15 @@
                         <hr>
                         <div class="form-group">
                             <label>新しいメールアドレス:</label>
-                            <input class="form-control" id="email" name="email" type="text" required>
+                            <input class="form-control" id="email" name="email" type="text"
+                                   {{if .newEmail}}
+                                   value="{{.newEmail}}"
+                                   {{end}}
+                                   required>
                         </div> <!-- form-group end.// -->
-                        {{if .msg}}
-                        <span style="color: red">{{.msg}}</span>
-                        {{end}}
                         <div class="form-group">
-                            <button type="submit" id="register-btn" class="btn btn-primary btn-block">メールアドレスを変更する</button>
+                            <button type="submit" id="update-btn" class="btn btn-primary btn-block">メールアドレスを変更する
+                            </button>
                         </div> <!-- form-group// -->
                     </form>
                 </article> <!-- card-body end .// -->

--- a/app/templates/profile/email_edit.js
+++ b/app/templates/profile/email_edit.js
@@ -1,0 +1,58 @@
+//有効値が入力されるまでボタンを無効化
+$(function () {
+  var button = $("#update-btn");
+  button.attr("disabled", true);
+});
+//メールアドレス形式のチェックおよび登録可能かチェック
+$(function () {
+  $("#email").on("input", function () {
+    //validation OKまで新規登録ボタンを無効化
+    var button = $("#update-btn");
+    button.attr("disabled", true);
+    var email_error = false;
+    //メールアドレスの形式チェック
+    if (
+      !/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+        $(this).val()
+      )
+    ) {
+      email_error = true;
+    }
+    if (email_error) {
+      if (!$(this).nextAll("span.error-info").length) {
+        $(this).after(
+          '<span class="text-danger error-info">有効なメールアドレスではありません。</span>'
+        );
+      }
+    } else {
+      //メールアドレス形式が問題ない場合、DB内にすでにアドレスが存在しないかチェック
+      $.ajax({
+        url: "/check_email", // 通信先のURL
+        type: "POST", // 使用するHTTPメソッド
+        data: JSON.stringify({ email: $(this).val() }),
+        contentType: "application/json",
+        dataType: "json", // responseのデータの種類
+        timespan: 1000, // 通信のタイムアウトの設定(ミリ秒)
+      })
+        //通信成功
+        .done(function (data, textStatus, jqXHR) {
+          //エラ〜メッセージを消す
+          if ($("#email").nextAll("span.error-info").length) {
+            $("#email").nextAll("span.error-info").remove();
+          }
+          if (data.valid === true) {
+            button.attr("disabled", false); // ボタンを再び enableにする
+          } else {
+            $("#email").after(
+              '<span class="text-danger error-info">このメールアドレスはすでに登録されています。</span>'
+            );
+          }
+        })
+        //通信失敗
+        .fail(function (xhr, status, error) {
+          // HTTPエラー時
+          //通信終了後
+        });
+    }
+  });
+});

--- a/app/templates/profile/password_edit.html
+++ b/app/templates/profile/password_edit.html
@@ -2,6 +2,8 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="/templates/profile/password_edit.js"></script>
 
     <title>パスワードの編集</title>
 </head>
@@ -22,7 +24,8 @@
                         <div class="form-row">
                             <div class="col form-group">
                                 <label>現在のパスワード:</label>
-                                <input type="password" id="current-password" name="current-password" class="form-control"
+                                <input type="password" id="current-password" name="current-password"
+                                       class="form-control" minlength="8"
                                        required>
                             </div> <!-- form-group end.// -->
                         </div> <!-- form-row end.// -->
@@ -35,11 +38,8 @@
                             <input class="form-control" id="password-confirm" type="password"
                                    placeholder="確認用にもう一度パスワードを入力" minlength="8" required>
                         </div> <!-- form-group end.// -->
-                        {{if .msg}}
-                        <span style="color: red">{{.msg}}</span>
-                        {{end}}
                         <div class="form-group">
-                            <button type="submit" id="register-btn" class="btn btn-primary btn-block">パスワードを変更する
+                            <button type="submit" id="update-btn" class="btn btn-primary btn-block">パスワードを変更する
                             </button>
                         </div> <!-- form-group// -->
                     </form>

--- a/app/templates/profile/password_edit.js
+++ b/app/templates/profile/password_edit.js
@@ -1,0 +1,73 @@
+//有効値が入力されるまでボタンを無効化
+$(function () {
+  var button = $("#update-btn");
+  button.attr("disabled", true);
+});
+
+//パスワードの文字数チェック
+$(function () {
+  $("#current-password").on("input", function () {
+    //validation OKまで新規登録ボタンを無効化
+    var button = $("#update-btn");
+    button.attr("disabled", true);
+    var password_error = false;
+    if ($(this).val().length < 8) {
+      password_error = true;
+    }
+    if (password_error) {
+      if (!$(this).nextAll("span.error-info").length) {
+        $(this).after(
+          '<span class="text-danger error-info">パスワードが８文字以下です。</span>'
+        );
+      }
+    } else {
+      if ($(this).nextAll("span.error-info").length) {
+        $(this).nextAll("span.error-info").remove();
+      }
+    }
+  });
+});
+
+//パスワードの文字数チェック
+$(function () {
+  $("#password").on("input", function () {
+    var password_error = false;
+    if ($(this).val().length < 8) {
+      password_error = true;
+    }
+    if (password_error) {
+      if (!$(this).nextAll("span.error-info").length) {
+        $(this).after(
+          '<span class="text-danger error-info">パスワードは８文字以上入力してください。</span>'
+        );
+      }
+    } else {
+      if ($(this).nextAll("span.error-info").length) {
+        $(this).nextAll("span.error-info").remove();
+      }
+    }
+  });
+});
+
+//確認用パスワードチェック
+$(function () {
+  $("#password-confirm").on("input", function () {
+    var button = $("#update-btn");
+    var confirm_pass_error = false;
+    if ($(this).val() !== $("#password").val()) {
+      confirm_pass_error = true;
+    }
+    if (confirm_pass_error) {
+      if (!$(this).nextAll("span.error-info").length) {
+        $(this).after(
+          '<span class="text-danger error-info">パスワードが一致しません。</span>'
+        );
+      }
+    } else {
+      button.attr("disabled", false);
+      if ($(this).nextAll("span.error-info").length) {
+        $(this).nextAll("span.error-info").remove();
+      }
+    }
+  });
+});

--- a/app/templates/profile/username_edit.html
+++ b/app/templates/profile/username_edit.html
@@ -2,7 +2,8 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
-
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="/templates/profile/username_edit.js"></script>
     <title>ユーザー名の編集</title>
 </head>
 <body>
@@ -30,11 +31,8 @@
                             <label>新しいユーザー名:</label>
                             <input class="form-control" id="username" name="username" type="text" required>
                         </div> <!-- form-group end.// -->
-                        {{if .msg}}
-                        <span style="color: red">{{.msg}}</span>
-                        {{end}}
                         <div class="form-group">
-                            <button type="submit" id="register-btn" class="btn btn-primary btn-block">ユーザー名を変更する
+                            <button type="submit" id="update-btn" class="btn btn-primary btn-block">ユーザー名を変更する
                             </button>
                         </div> <!-- form-group// -->
                     </form>

--- a/app/templates/profile/username_edit.js
+++ b/app/templates/profile/username_edit.js
@@ -1,0 +1,17 @@
+//入力されるまでボタンを無効化
+$(function () {
+  var button = $("#update-btn");
+  button.attr("disabled", true);
+});
+
+//ユーザー名の文字数チェック
+$(function () {
+  $("#username").on("input", function () {
+    var button = $("#update-btn");
+    if ($(this).val().length > 0) {
+      button.attr("disabled", false);
+    } else {
+      button.attr("disabled", true);
+    }
+  });
+});


### PR DESCRIPTION
1: メールアドレスが無効な場合、入力値を入れたままになるよう修正
2: 新規登録時と同様に、バリデーションをクリアするまでボタンを無効化するよう設定