### PR TITLE
DBのFind関数の返り型を変更

### DIFF
--- a/app/controllers/auth/login_handler.go
+++ b/app/controllers/auth/login_handler.go
@@ -2,72 +2,61 @@ package auth
 
 import (
 	"app/dbhandler"
-	"app/model"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
-	"log"
 	"net/http"
 	"net/url"
 )
 
 func Login(w http.ResponseWriter, req *http.Request) {
 	//エラーメッセージを定義
-	msg := "エラ〜が発生しました。もう一度操作をしなおしてください。"
+	msg := "エラーが発生しました。もう一度操作をしなおしてください。"
 	//Validation完了後のメールアドレスを取得
 	email, ok := req.Context().Value("email").(string)
 	if !ok {
+		//入力されたメールアドレスを保持する
+		email = url.QueryEscape(email)
 		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
 	}
 	//Validation完了後のパスワードを取得
 	password, ok := req.Context().Value("password").(string)
 	if !ok {
+		//入力されたメールアドレスを保持する
+		email = url.QueryEscape(email)
 		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
 	}
+
+	//以下のコード内のエラーメッセージ
+	msg2 := "メールアドレスまたはパスワードが正しくありません。"
 
 	//取得するドキュメントの条件
 	userDoc := bson.D{{"email", email}}
 	//DBから取得
-	resp, err := dbhandler.Find("googroutes", "users", userDoc, nil)
+	respUDoc, err := dbhandler.Find("googroutes", "users", userDoc, nil)
+	//入力されたメールアドレスを保持する
+	email = url.QueryEscape(email)
 	if err != nil {
-		msg = "メールアドレスまたはパスワードが正しくありません。"
-		//入力されたメールアドレスを保持する
-		email = url.QueryEscape(email)
-		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
-		return
-	}
-	//DBから取得した値をmarshal
-	bsonByte, err := bson.Marshal(resp)
-	if err != nil {
-		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
-		email = url.QueryEscape(email)
-		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
-		log.Printf("Error while bson marshaling user document: %v", err)
-		return
-	}
-	var user model.UserData
-	//marshalした値をUnmarshalして、userに代入
-	err = bson.Unmarshal(bsonByte, &user)
-	if err != nil {
-		msg = "エラ〜が発生しました。もう一度操作しなおしてください。"
-		email = url.QueryEscape(email)
-		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
-		log.Printf("Error while bson unmarshaling :%v", err)
+		http.Redirect(w, req, "/login_form/?msg="+msg2+"&email="+email, http.StatusSeeOther)
 		return
 	}
 
-	storedPass := user.Password
+	storedPassB,ok := respUDoc["password"].(primitive.Binary)
+	if !ok {
+		http.Redirect(w, req, "/login_form/?msg="+msg2+"&email="+email, http.StatusSeeOther)
+		return
+	}
+	storedPass := storedPassB.Data
 	//DB内のハッシュ化されたパスワードと入力されたパスワードの一致を確認
 	err = bcrypt.CompareHashAndPassword(storedPass, []byte(password))
 	//一致しない場合
 	if err != nil {
-		msg = "メールアドレスまたはパスワードが正しくありません。"
-		//入力されたメールアドレスを保持する
-		email = url.QueryEscape(email)
-		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)
+		http.Redirect(w, req, "/login_form/?msg="+msg2+"&email="+email, http.StatusSeeOther)
 		return
 	}
 	//一致した場合
-	err = genNewSession(user.ID, w)
+	userID := respUDoc["_id"].(primitive.ObjectID)
+	err = genNewSession(userID, w)
 	if err != nil {
 		msg = " ログインに失敗しました。もう一度操作をしなおしてください。"
 		http.Redirect(w, req, "/login_form/?msg="+msg+"&email="+email, http.StatusSeeOther)

--- a/app/controllers/middleware/auth.go
+++ b/app/controllers/middleware/auth.go
@@ -85,13 +85,16 @@ func getLoginUser(userID primitive.ObjectID) (model.UserData, error) {
 	//DBから取得した値をmarshal
 	bsonByte, err := bson.Marshal(resp)
 	if err != nil {
-		log.Printf("Error while bson marshaling session data: %v", err)
+		log.Printf("Error while bson marshaling user data: %v", err)
 		return model.UserData{}, err
 	}
 
 	var user model.UserData
 	//marshalした値をUnmarshalして、userに代入
-	bson.Unmarshal(bsonByte, &user)
-
+	err = bson.Unmarshal(bsonByte, &user)
+	if err != nil {
+		log.Printf("Error while bson unmarshaling user data: %v", err)
+		return model.UserData{}, err
+	}
 	return user, nil
 }

--- a/app/controllers/middleware/auth.go
+++ b/app/controllers/middleware/auth.go
@@ -18,7 +18,7 @@ func Auth(next http.HandlerFunc) http.HandlerFunc {
 		data := map[string]interface{}{"isLoggedIn": false} //初期値はログインしていないとしてfalse
 
 		//sessionデータを取得
-		session, err := getSession(req)
+		session, err := getUserIDFromSession(req)
 		if err != nil {
 			ctx = context.WithValue(ctx, "data", data)
 			next.ServeHTTP(w, req.WithContext(ctx))
@@ -43,35 +43,27 @@ func Auth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-func getSession(req *http.Request) (model.SessionData, error) {
+func getUserIDFromSession(req *http.Request) (primitive.ObjectID, error) {
 	//Cookieからセッション情報取得
 	c, err := req.Cookie("session_id")
 	//Cookieが設定されてない場合
 	if err != nil {
-		return model.SessionData{}, err
+		return primitive.NilObjectID, err
 	}
 
 	//tokenからsessionID取得
 	sessionID, _ := auth.ParseToken(c.Value)
 	sessionDoc := bson.D{{"session_id", sessionID}}
 	//DBから読み込み
-	resp, err := dbhandler.Find("googroutes", "sessions", sessionDoc, nil)
+	sBSON, err := dbhandler.Find("googroutes", "sessions", sessionDoc, nil)
 	if err != nil {
 		log.Printf("Error while finding session data: %v", err)
-		return model.SessionData{}, err
+		return primitive.NilObjectID, err
 	}
 
-	//DBから取得した値をmarshal
-	bsonByte, err := bson.Marshal(resp)
-	if err != nil {
-		log.Printf("Error while bson marshaling session data: %v", err)
-		return model.SessionData{}, err
-	}
+	userID := sBSON["user_id"].(primitive.ObjectID)
 
-	var session model.SessionData
-	//marshalした値をUnmarshalして、userに代入
-	bson.Unmarshal(bsonByte, &session)
-	return session, nil
+	return userID, nil
 }
 
 func getLoginUser(userID primitive.ObjectID) (model.UserData, error) {

--- a/app/dbhandler/find_handler.go
+++ b/app/dbhandler/find_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 ///optionDoc(フィールド指定)は順番関係ないからtypeはDでなくM
-func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (bson.D, error) {
+func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (interface{}, error) {
 	client, ctx, cancel, err := connectDB()
 	defer cancel()
 	if err != nil {

--- a/app/dbhandler/find_handler.go
+++ b/app/dbhandler/find_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 ///optionDoc(フィールド指定)は順番関係ないからtypeはDでなくM
-func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (interface{}, error) {
+func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (bson.D, error) {
 	client, ctx, cancel, err := connectDB()
 	defer cancel()
 	if err != nil {

--- a/app/dbhandler/find_handler.go
+++ b/app/dbhandler/find_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 ///optionDoc(フィールド指定)は順番関係ないからtypeはDでなくM
-func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (interface{}, error) {
+func Find(dbName, collectionName string, document interface{}, optionDoc bson.M) (bson.M, error) {
 	client, ctx, cancel, err := connectDB()
 	defer cancel()
 	if err != nil {
@@ -21,7 +21,7 @@ func Find(dbName, collectionName string, document interface{}, optionDoc bson.M)
 	collection := database.Collection(collectionName)
 	opts := options.FindOne().SetProjection(optionDoc)
 	//DBからのレスポンスを挿入する変数
-	var response bson.D
+	var response bson.M
 	err = collection.FindOne(ctx, document, opts).Decode(&response)
 	if err != nil {
 		if err != mongo.ErrNoDocuments {

--- a/app/dbhandler/insert_handler.go
+++ b/app/dbhandler/insert_handler.go
@@ -1,13 +1,15 @@
 package dbhandler
 
-import "go.mongodb.org/mongo-driver/mongo"
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
-func Insert(dbName, collectionName string, document interface{}) (*mongo.InsertOneResult, error) {
+func Insert(dbName, collectionName string, document interface{}) (primitive.ObjectID, error) {
 	//objectIDを取得するには、１番目の帰り値のInsertedIDフィールドを取得する
 	client, ctx, cancel, err := connectDB()
 	defer cancel()
 	if err != nil {
-		return nil, err
+		return primitive.NilObjectID, err
 	}
 	//処理終了後に切断
 	defer client.Disconnect(ctx)
@@ -15,7 +17,7 @@ func Insert(dbName, collectionName string, document interface{}) (*mongo.InsertO
 	collection := database.Collection(collectionName)
 	insertRes, err := collection.InsertOne(ctx, document)
 	if err != nil {
-		return nil, err
+		return primitive.NilObjectID, err
 	}
-	return insertRes, nil
+	return insertRes.InsertedID.(primitive.ObjectID), nil
 }

--- a/app/main.go
+++ b/app/main.go
@@ -32,7 +32,7 @@ func main() {
 	http.HandleFunc("/ask_confirm", middleware.Auth(auth.AskConfirmEmail))    //メールアドレス確認依頼画面
 	http.HandleFunc("/login_form/", middleware.Auth(auth.LoginForm))          //ログイン画面
 	http.HandleFunc("/login", middleware.LoginValidator(auth.Login))          //ログイン実行用エンドポイント
-	http.HandleFunc("/confirm_register", auth.ConfirmRegister)                //本登録実行用エンドポイント
+	http.HandleFunc("/confirm_register/", auth.ConfirmRegister)                //本登録実行用エンドポイント
 	http.HandleFunc("/logout", auth.Logout)                                   //ログアウト用エンドポイント
 
 	//「まとめ検索」

--- a/app/model/model.go
+++ b/app/model/model.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"time"
 )
 
 type UserData struct {
@@ -10,13 +9,7 @@ type UserData struct {
 	UserName         string               `json:"username" bson:"username"`
 	Email            string               `json:"email" bson:"email"`
 	Password         []byte               `json:"password" bson:"password"`
-	MultiRouteTitles map[string]time.Time `json:"multi_route_titles" bson:"multi_route_titles"`
-}
-
-type SessionData struct {
-	ID        primitive.ObjectID `json:"id" bson:"_id"`
-	SessionId string             `json:"session_id" bson:"session_id"`
-	UserID    primitive.ObjectID `json:"user_id" bson:"user_id"`
+	//MultiRouteTitles map[string]time.Time `json:"multi_route_titles" bson:"multi_route_titles"`
 }
 
 //ルート編集保存requestのフィールドを保存するstruct


### PR DESCRIPTION
1: DBの処理で、Findで取得したものは全てmarshalした後unmarshalしていたが、返り型をbson.Mにすることで、mapと同様に値を扱えるようにした。ただし、type assertionを追加する必要がある