### PR TITLE
Apキーがクライアント側から見れないよう修正

### DIFF
--- a/app/controllers/apikey/get_apikey.go
+++ b/app/controllers/apikey/get_apikey.go
@@ -1,0 +1,45 @@
+package apikey
+
+import (
+	"app/envhandler"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+func GetApiKey(w http.ResponseWriter, req *http.Request) {
+	apiKey, err := envhandler.GetEnvVal("MAP_API_KEY")
+	if err != nil || apiKey == "" {
+		http.Error(w, "エラーが発生しました。", http.StatusBadRequest)
+		log.Println("Couldn't get API Key from env file")
+		return
+	}
+
+	//Google Maps APIのJavascriptファイルを取得するURLを生成
+	baseURL := "https://maps.googleapis.com/maps/api/js?key="
+	optsURL := "&libraries=places&v=weekly&language=ja"
+	reqURL := baseURL + apiKey + optsURL
+
+	//Javascriptファイルを取得
+	apiRes, err := http.Get(reqURL)
+	if err != nil {
+		http.Error(w, "エラーが発生しました。", http.StatusBadRequest)
+		log.Printf("Couldn't get file response from Google Maps API seervice %v", err)
+		return
+	}
+	//HTTPレスポンスとして渡せるよう[]byte型にする
+	srcJS, err := ioutil.ReadAll(apiRes.Body)
+	if err != nil {
+		http.Error(w, "エラーが発生しました。", http.StatusBadRequest)
+		log.Printf("Error while reading file returned from Google Maps API service: %v", err)
+		return
+	}
+
+	//レスポンス作成
+	w.Header().Set("Content-Type", "text/javascript;charset=UTF-8")
+	_, err = w.Write(srcJS)
+	if err != nil {
+		log.Printf("Error while returning javascript file for Google Maps API service: %v", err)
+		return
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"app/controllers/apikey"
 	"app/controllers/auth"
 	"app/controllers/multiroute"
 	"app/controllers/mypage"
@@ -38,6 +39,7 @@ func main() {
 
 	//「まとめ検索」
 	http.HandleFunc("/multi_search", middleware.Auth(multiroute.MultiSearchTpl))                                 //検索画面
+	http.HandleFunc("/get_apikey", apikey.GetApiKey)                                                             //Google Maps API Javascriptの実行に必要なJavascriptファイルを取得するためのエンドポイント
 	http.HandleFunc("/get_timezone", middleware.Auth(multiroute.GetTimezone))                                    //タイムゾーン取得用エンドポイント
 	http.HandleFunc("/routes_save", middleware.Auth(reqvalidator.SaveRoutesValidator(multiroute.SaveRoutes)))    //保存用エンドポイント
 	http.HandleFunc("/show_route/", middleware.Auth(multiroute.ShowAndEditRoutesTpl))                            //確認編集画面

--- a/app/templates/multi_search/search/multi_search.html
+++ b/app/templates/multi_search/search/multi_search.html
@@ -3,12 +3,7 @@
 <head>
     <title>ルート検索</title>
     {{ template "imports" }}
-    <!--GoogleMaps APIの呼び出し-->
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
-    <script
-            src="https://maps.googleapis.com/maps/api/js?key={{.apiKey}}&callback=initMap&libraries=places&v=weekly"
-            defer
-    ></script>
 
     <link rel="stylesheet" type="text/css" href="templates/multi_search/search/multi_search.css"/>
     <script src="templates/multi_search/search/multi_search.js"></script>

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -76,6 +76,21 @@ var clock = hr + ":" + minu + ":00";
 //ブラウザのタイムゾーンのUTCからの時差をminutes単位で取得
 var tzoneOffsetminu = today.getTimezoneOffset();
 
+//Google Maps API実行ファイル読み込み
+window.onload = function () {
+  fetch("/get_apikey")
+    .then((resp) => {
+      return resp.text();
+    })
+    .then((MapJS) => {
+      window.Function(MapJS)(); //ファイル実行
+      initMap(); //APIリクエストのcallbackではなくここで実行
+    })
+    .catch(() => {
+      alert("エラーが発生しました。");
+    });
+};
+
 function initMap() {
   const map = new google.maps.Map(document.getElementById("map"), {
     mapTypeControl: false,
@@ -409,9 +424,9 @@ class AutocompleteDirectionsHandler {
         me.getTimeZone(me);
 
         /*(ブラウザのタイムゾーンの時刻) ー (ブラウザのタイムゾーンのoffset) ー (入力地のタイムゾーンのoffset) = (入力地のタイムゾーンの時刻)
-        例:ロサンゼルスの鉄道の3月1日,10:00出発を調べたい場合、
-        (3月1日,10:00 Asia/Tokyo) -(-9 hors) - (-8 hours) = (3月2日 3:00 Asia/Tokyo) = (3月1日,10:00 America/Los_Angeles)
-        (注意)Javascriptの場合、offsetはGMTより進んでいる場合、マイナスになり、TimeZone APIの場合、逆に進んでいる場合プラスになる*/
+                例:ロサンゼルスの鉄道の3月1日,10:00出発を調べたい場合、
+                (3月1日,10:00 Asia/Tokyo) -(-9 hors) - (-8 hours) = (3月2日 3:00 Asia/Tokyo) = (3月1日,10:00 America/Los_Angeles)
+                (注意)Javascriptの場合、offsetはGMTより進んでいる場合、マイナスになり、TimeZone APIの場合、逆に進んでいる場合プラスになる*/
         specTime.setHours(
           specTime.getHours() -
             Math.round(tzoneOffsetminu / 60) -

--- a/app/templates/multi_search/show_and_edit/multi_route_show.html
+++ b/app/templates/multi_search/show_and_edit/multi_route_show.html
@@ -7,12 +7,8 @@
     <script>routeInfo = JSON.parse(
         {{.routeInfo}});
     </script>
-    <!--GoogleMaps APIの呼び出し-->
+
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
-    <script
-            src="https://maps.googleapis.com/maps/api/js?key={{.apiKey}}&callback=initMap&libraries=places&v=weekly"
-            defer
-    ></script>
 
     <link rel="stylesheet" type="text/css" href="/templates/multi_search/show_and_edit/multi_route_show.css"/>
     <script src="/templates/multi_search/show_and_edit/multi_route_show.js"></script>

--- a/app/templates/multi_search/show_and_edit/multi_route_show.js
+++ b/app/templates/multi_search/show_and_edit/multi_route_show.js
@@ -76,6 +76,21 @@ var clock = hr + ":" + minu + ":00";
 //ブラウザのタイムゾーンのUTCからの時差をminutes単位で取得
 var tzoneOffsetminu = today.getTimezoneOffset();
 
+//Google Maps API実行ファイル読み込み
+window.onload = function () {
+  fetch("/get_apikey")
+    .then((resp) => {
+      return resp.text();
+    })
+    .then((MapJS) => {
+      window.Function(MapJS)(); //ファイル実行
+      initMap(); //APIリクエストのcallbackではなくここで実行
+    })
+    .catch(() => {
+      alert("エラーが発生しました。");
+    });
+};
+
 function initMap() {
   const map = new google.maps.Map(document.getElementById("map"), {
     mapTypeControl: false,
@@ -451,9 +466,9 @@ class AutocompleteDirectionsHandler {
         me.getTimeZone(me);
 
         /*(ブラウザのタイムゾーンの時刻) ー (ブラウザのタイムゾーンのoffset) ー (入力地のタイムゾーンのoffset) = (入力地のタイムゾーンの時刻)
-        例:ロサンゼルスの鉄道の3月1日,10:00出発を調べたい場合、
-        (3月1日,10:00 Asia/Tokyo) -(-9 hors) - (-8 hours) = (3月2日 3:00 Asia/Tokyo) = (3月1日,10:00 America/Los_Angeles)
-        (注意)Javascriptの場合、offsetはGMTより進んでいる場合、マイナスになり、TimeZone APIの場合、逆に進んでいる場合プラスになる*/
+                例:ロサンゼルスの鉄道の3月1日,10:00出発を調べたい場合、
+                (3月1日,10:00 Asia/Tokyo) -(-9 hors) - (-8 hours) = (3月2日 3:00 Asia/Tokyo) = (3月1日,10:00 America/Los_Angeles)
+                (注意)Javascriptの場合、offsetはGMTより進んでいる場合、マイナスになり、TimeZone APIの場合、逆に進んでいる場合プラスになる*/
         specTime.setHours(
           specTime.getHours() -
             Math.round(tzoneOffsetminu / 60) -


### PR DESCRIPTION
1: templateファイルでAPI キーを埋め込むと、ソースコードではAPIキーがわからないが、実行時にブラウザで見れてしまう問題があった。そこでHTMLからAPIの実行ファイルを直接読み込むのでなく、Javascriptからサーバー経由で読み込むようにした。

2: HTMLから直接読み込むときはブラウザのロケーションから言語設定を自動で読み取っていたのだと思われるが、サーバー経由だとロケーション情報がないため、英語設定となった。サーバー経由の場合、クエリーパラメータでlanguageを指定する必要がある。