### PR TITLE
API Keyの非表示化

### DIFF
--- a/app/controllers/simulsearch/tpl_handler.go
+++ b/app/controllers/simulsearch/tpl_handler.go
@@ -1,7 +1,6 @@
 package simulsearch
 
 import (
-	"app/envhandler"
 	"html/template"
 	"log"
 	"net/http"
@@ -22,13 +21,6 @@ func SimulSearchTpl(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, "/?msg="+msg, http.StatusInternalServerError)
 		return
 	}
-	//envファイルからAPIキー取得
-	apiKey, err := envhandler.GetEnvVal("MAP_API_KEY")
-	if err != nil {
-		http.Redirect(w, req, "/?msg="+msg, http.StatusInternalServerError)
-		return
-	}
-	data["apiKey"] = apiKey
 	nineIterator := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	data["nineIterator"] = nineIterator
 	simulSearchTpl.ExecuteTemplate(w, "simul_search.html", data)

--- a/app/dev_memo.txt
+++ b/app/dev_memo.txt
@@ -57,3 +57,7 @@ dbhandler.UpdateOne("googroutes", "users", "$unset", userDoc, deleteField)
 
   GAE(Google Cloud App Engine)は、サーバー側でTLS処理をしてくれるから、ListenAndServeTLS
 を使わないでListenAndServeを使えばいい
+
+　API KeyがHTML内に表示されないよう、Javascriptから、APIの実行ファイルを取得するよう変更したが、
+Developperツールでファイル取得時のレスポンスでAPI Keyが発見されたので、完全にAPI Keyを秘密にするのは
+不可能そう

--- a/app/templates/simul_search/simul_search.html
+++ b/app/templates/simul_search/simul_search.html
@@ -8,11 +8,7 @@
 
     <!--Javascript-->
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
-    <!--Google Maps APIの読み込み-->
-    <script
-            src="https://maps.googleapis.com/maps/api/js?key={{.apiKey}}&callback=initAutocomplete&libraries=places&v=weekly"
-            defer
-    ></script>
+
     <script src="templates/simul_search/simul_search.js"></script>
 </head>
 

--- a/app/templates/simul_search/simul_search.js
+++ b/app/templates/simul_search/simul_search.js
@@ -95,6 +95,21 @@ var hr = ("0" + today.getHours()).slice(-2);
 var minu = ("0" + today.getMinutes()).slice(-2);
 var clock = hr + ":" + minu + ":00";
 
+
+//Google Maps API実行ファイル読み込み
+window.onload = function () {
+  fetch("/get_apikey")
+      .then((resp) => {
+        return resp.text();
+      })
+      .then((MapJS) => {
+        window.Function(MapJS)(); //ファイル実行
+        initAutocomplete(); //APIリクエストのcallbackではなくここで実行
+      })
+      .catch(() => {
+        alert("エラーが発生しました。");
+      });
+};
 //出発地と目的地の自動入力を設定
 function initAutocomplete() {
   // 日付を設定


### PR DESCRIPTION
1: simul_searchの実行時、API  Keyがtemplateに埋め込まれるままだったので、Javascriptから実行ファイルを取得するよう変更

*HTMLには表示されないので見つけづらくはなるが、Developper Consoleを使われると、完全に秘密にすることはできなそう