### PR TITLE
リクエストバリデーターのリファクタリング

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -44,7 +44,7 @@ func main() {
 	http.HandleFunc("/get_apikey", apikey.GetApiKey)                                                             //Google Maps API Javascriptの実行に必要なJavascriptファイルを取得するためのエンドポイント
 	http.HandleFunc("/get_timezone", middleware.Auth(multiroute.GetTimezone))                                    //タイムゾーン取得用エンドポイント
 	http.HandleFunc("/routes_save", middleware.Auth(reqvalidator.SaveRoutesValidator(multiroute.SaveNewRoute)))  //保存用エンドポイント
-	http.HandleFunc("/show_route", middleware.Auth(multiroute.ShowAndEditRoutesTpl))                             //確認編集画面
+	http.HandleFunc("/show_route/", middleware.Auth(multiroute.ShowAndEditRoutesTpl))                            //確認編集画面
 	http.HandleFunc("/update_route", middleware.Auth(reqvalidator.UpdateRouteValidator(multiroute.UpdateRoute))) //編集用エンドポイント
 	http.HandleFunc("/delete_route", middleware.Auth(multiroute.DeleteRoute))                                    //削除用エンドポイント
 

--- a/app/reqvalidator/multiroute_validator.go
+++ b/app/reqvalidator/multiroute_validator.go
@@ -1,34 +1,76 @@
 package reqvalidator
 
 import (
-	"app/model"
 	"app/controllers/multiroute"
+	"app/customerr"
+	"app/model"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
 )
 
+type multiRouteValidator struct {
+	err error
+}
+
+func (m *multiRouteValidator) checkHTTPMethod(req *http.Request) {
+	if req.Header.Get("Content-Type") != "application/json" || req.Method != "POST" {
+		m.err = customerr.BaseErr{
+			Op:  "check HTTP method",
+			Msg: "HTTPメソッドが不正です。",
+			Err: fmt.Errorf("invalid HTTP method access"),
+		}
+		return
+	}
+}
+
+func (m *multiRouteValidator) convertJSONToStruct(req *http.Request, reqFields interface{}) {
+	if m.err != nil {
+		return
+	}
+	body, _ := ioutil.ReadAll(req.Body)
+	err := json.Unmarshal(body, reqFields)
+	if err != nil {
+		m.err = customerr.BaseErr{
+			Op:  "json unmarshal multi route request",
+			Msg: "入力に不正があります。",
+			Err: fmt.Errorf("error while json unmarshaling multiroute request: %w", err),
+		}
+		return
+	}
+}
+
+func (m *multiRouteValidator) checkContainedChar(title string) {
+	if m.err != nil {
+		return
+	}
+	if strings.ContainsAny(title, ".$") {
+		m.err = customerr.BaseErr{
+			Op:  "check contained character in route's title",
+			Msg: "ルート名にご使用いただけない文字が含まれています。",
+			Err: fmt.Errorf(". or $ was contained in route title"),
+		}
+		return
+	}
+}
+
 func SaveRoutesValidator(SaveRoutes http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		if req.Method != "POST" {
-			http.Error(w, "HTTPメソッドが不正です。", http.StatusBadRequest)
-			return
-		}
-		//requestのフィールドを保存する変数
+		var m multiRouteValidator
+		m.checkHTTPMethod(req)
+		//convertJSONToStructの第２引数はinterfaceなので、変数を宣言してポインタを渡す必要がある
 		var reqFields model.MultiRoute
-		body, _ := ioutil.ReadAll(req.Body)
-		err := json.Unmarshal(body, &reqFields)
-		if err != nil {
-			http.Error(w, "入力に不正があります。", http.StatusBadRequest)
-			log.Printf("Error while json marshaling: %v", err)
-			return
-		}
+		m.convertJSONToStruct(req, &reqFields)
+		m.checkContainedChar(reqFields.Title)
 
-		if strings.ContainsAny(reqFields.Title, ".$") {
-			http.Error(w, "ルート名にご使用いただけない文字が含まれています。", http.StatusBadRequest)
+		if m.err != nil {
+			e := m.err.(customerr.BaseErr)
+			http.Error(w, e.Msg, http.StatusBadRequest)
+			log.Printf("operation: %s, error: %v", e.Op, e.Err)
 			return
 		}
 
@@ -41,22 +83,17 @@ func SaveRoutesValidator(SaveRoutes http.HandlerFunc) http.HandlerFunc {
 
 func UpdateRouteValidator(UpdateRoute http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		if req.Method != "POST" {
-			http.Error(w, "HTTPメソッドが不正です。", http.StatusBadRequest)
-			return
-		}
-
+		var m multiRouteValidator
+		m.checkHTTPMethod(req)
+		//convertJSONToStructの第２引数はinterfaceなので、変数を宣言してポインタを渡す必要がある
 		var reqFields multiroute.RouteUpdateRequest
-		body, _ := ioutil.ReadAll(req.Body)
-		err := json.Unmarshal(body, &reqFields)
-		if err != nil {
-			http.Error(w, "入力に不正があります。", http.StatusInternalServerError)
-			log.Printf("Error while json marshaling: %v", err)
-			return
-		}
+		m.convertJSONToStruct(req, &reqFields)
+		m.checkContainedChar(reqFields.Title)
 
-		if strings.ContainsAny(reqFields.Title, ".$") {
-			http.Error(w, "ルート名にご使用いただけない文字が含まれています。", http.StatusBadRequest)
+		if m.err != nil {
+			e := m.err.(customerr.BaseErr)
+			http.Error(w, e.Msg, http.StatusBadRequest)
+			log.Printf("operation: %s, error: %v", e.Op, e.Err)
 			return
 		}
 


### PR DESCRIPTION
1: reqvalidator package内のコードをプロセスごとにメソッドに分割してコードの可読性改善
2: multiroute_validator.goのconvertJSONToStructは2つの型を引数にとるため、引数をinterfaceに設定
3: convertJSONToStructを使用する際、先に変数宣言してポインタを渡すようにする必要がある