### PR TITLE
バケット名とファイル名を置換するよう変更

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'
-    args: ['-c','cd app && mkdir env && gsutil cp gs://ggrt/.env env/prod.env' ]
+    args: ['-c','cd app && mkdir env && gsutil cp gs://${_ENV_BUCKET_NAME}/${_ENV_FILE_NAME} env/prod.env' ]
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args: [ '-c', 'cd app && gcloud config set app/cloud_build_timeout 1600 && gcloud app deploy' ]


### PR DESCRIPTION
1: バケット名とファイル名が丸見えなのはよくないので、置換を利用するよう変更