### PR TITLE
同時検索の検索結果の保存機能作成

### DIFF
--- a/app/controllers/simulsearch/save_route.go
+++ b/app/controllers/simulsearch/save_route.go
@@ -1,0 +1,83 @@
+package simulsearch
+
+import (
+	"app/contexthandler"
+	"app/customerr"
+	"app/model"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type simulRouteData struct {
+	simulRoute model.SimulRoute
+	user       model.User
+	err        error
+}
+
+//getSimulRouteFromCtx gets simulRoute from request's context
+func (s *simulRouteData) getSimulRouteFromCtx(req *http.Request) {
+	simulRouteFields, ok := req.Context().Value("simulRouteFields").(model.SimulRoute)
+	if !ok {
+		s.err = customerr.BaseErr{
+			Op:  "Get req routes info from context",
+			Msg: "エラーが発生しました。",
+			Err: fmt.Errorf("error while getting request fields from reuest's context"),
+		}
+	}
+	s.simulRoute = simulRouteFields
+}
+
+//saveRoute saves route document to routes collection
+func (s *simulRouteData) saveRoute() {
+	err := s.simulRoute.SaveRoute(s.user.ID)
+	if err != nil {
+		e := customerr.BaseErr{
+			Op:  "Save new simul route",
+			Err: fmt.Errorf("error while saving simul route: %w", err),
+		}
+
+		e.Msg = "エラーが発生しました。"
+		s.err = e
+	}
+}
+
+//addRouteTitle adds simulroute_titles field to user document
+func (s *simulRouteData) addRouteTitle() {
+	if s.err != nil {
+		return
+	}
+	now := time.Now().UTC() //MongoDBでは、timeはUTC表記で扱われ、タイムゾーン情報は入れられない
+	err := model.UpdateSimulRouteTitles(s.user.ID, s.simulRoute.Title, "$set", now)
+	if err != nil {
+		s.err = customerr.BaseErr{
+			Op:  "update user document's simul_route_titles field",
+			Msg: "エラーが発生しました。",
+			Err: fmt.Errorf("error while updating user's simul_route_titles %w", err),
+		}
+		return
+	}
+}
+
+func SaveNewRoute(w http.ResponseWriter, req *http.Request) {
+	var s = &simulRouteData{}
+	s.getSimulRouteFromCtx(req)
+	contexthandler.GetUserFromCtx(req, &s.user, &s.err)
+	s.saveRoute()
+	/*users collectionのsimul_route_titlesフィールドにルート名と作成時刻を追加($set)する。
+	  作成時刻はルート名取得時に作成時刻でソートするため*/
+	s.addRouteTitle()
+
+	if s.err != nil {
+		e := s.err.(customerr.BaseErr)
+		http.Error(w, e.Msg, http.StatusInternalServerError)
+		log.Printf("operation: %s, error: %v", e.Op, e.Err)
+	}
+
+	//レスポンス作成
+	w.Header().Set("Content-Type", "application/json")
+	msgJSON := map[string]string{"msg": "OK"}
+	json.NewEncoder(w).Encode(&msgJSON)
+}

--- a/app/main.go
+++ b/app/main.go
@@ -48,8 +48,9 @@ func main() {
 	http.HandleFunc("/delete_route", middleware.Auth(multiroute.DeleteRoute))                                    //削除用エンドポイント
 
 	//「同時検索」
-	http.HandleFunc("/simul_search", middleware.Auth(simulsearch.SimulSearchTpl))                     //検索画面
-	http.HandleFunc("/do_simul_search", reqvalidator.SimulSearchValidator(simulsearch.DoSimulSearch)) //検索実行用エンドポイント
+	http.HandleFunc("/simul_search", middleware.Auth(simulsearch.SimulSearchTpl))                                                 //検索画面
+	http.HandleFunc("/do_simul_search", reqvalidator.SimulSearchValidator(simulsearch.DoSimulSearch))                             //検索実行用エンドポイント
+	http.HandleFunc("/simul_search/routes_save", middleware.Auth(reqvalidator.SaveSimulRouteValidator(simulsearch.SaveNewRoute))) //保存用エンドポイント
 
 	//「マイページ」
 	http.HandleFunc("/mypage", middleware.Auth(mypage.ShowMypage))                 //マイページ表示

--- a/app/model/simul_route.go
+++ b/app/model/simul_route.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"app/dbhandler"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type SimulRouteData struct {
+	Destination string `json:"destination" bson:"destination"`
+	//Distance and Duration are stored as string here. They are processed as a number
+	//at DoSimulSearch() in app/controllers/simulsearch/simul_search.go
+	Distance string `json:"distance" bson:"distance"`
+	Duration string `json:"duration" bson:"duration"`
+}
+
+type SimulRoute struct {
+	ID          primitive.ObjectID        `json:"_id" bson:"_id"`
+	Title       string                    `json:"title" bson:"title"`
+	SimulRoutes map[string]SimulRouteData `json:"simul_routes" bson:"simul_routes"`
+}
+
+func (s *SimulRoute) SaveRoute(userID primitive.ObjectID) error {
+	routeDocument := bson.D{
+		{"user_id", userID},
+		{"title", s.Title},
+		{"simul_routes", s.SimulRoutes},
+	}
+	_, err := dbhandler.Insert("googroutes", "simulroutes", routeDocument)
+	return err
+}
+
+func (s *SimulRoute) UpdateSimulRoute() error {
+	//routes collectionに保存
+	routeDoc := bson.M{"_id": s.ID}
+	updateDoc := bson.D{
+		{"title", s.Title},
+		{"simul_routes", s.SimulRoutes},
+	}
+	err := dbhandler.UpdateOne("googroutes", "simulroutes", "$set", routeDoc, updateDoc)
+	return err
+}
+
+func FindSimulRoute(userID primitive.ObjectID, title string) (bson.M, error) {
+	//routes collectionから取得
+	simulRouteDoc := bson.D{{"user_id", userID}, {"title", title}}
+	r, err := dbhandler.Find("googroutes", "simulroutes", simulRouteDoc, nil)
+	return r, err
+}

--- a/app/reqvalidator/simulroute_validator.go
+++ b/app/reqvalidator/simulroute_validator.go
@@ -1,0 +1,107 @@
+package reqvalidator
+
+import (
+	"app/customerr"
+	"app/model"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type simulRouteValidator struct {
+	err error
+}
+
+//checkHTTPMethod checks request's Content-Type and HTTP methods
+func (s *simulRouteValidator) checkHTTPMethod(req *http.Request) {
+	if req.Header.Get("Content-Type") != "application/json" || req.Method != "POST" {
+		s.err = customerr.BaseErr{
+			Op:  "check HTTP method",
+			Msg: "HTTPメソッドが不正です。",
+			Err: fmt.Errorf("invalid HTTP method access"),
+		}
+		return
+	}
+}
+
+//checkContainedChar checks if routeTitle contains . or $
+func (s *simulRouteValidator) checkContainedChar(title string) {
+	if s.err != nil {
+		return
+	}
+	if strings.ContainsAny(title, ".$") {
+		s.err = customerr.BaseErr{
+			Op:  "check contained character in route's title",
+			Msg: "ルート名にご使用いただけない文字が含まれています。",
+			Err: fmt.Errorf(". or $ was contained in route title"),
+		}
+		return
+	}
+}
+
+//convertJSONToStruct converts request's JSON data to multiRoute struct
+func (s *simulRouteValidator) convertJSONToStruct(req *http.Request, reqFields interface{}) {
+	if s.err != nil {
+		return
+	}
+	body, _ := ioutil.ReadAll(req.Body)
+	err := json.Unmarshal(body, reqFields)
+	if err != nil {
+		s.err = customerr.BaseErr{
+			Op:  "json unmarshal multi route request",
+			Msg: "入力に不正があります。",
+			Err: fmt.Errorf("error while json unmarshaling multiroute request: %w", err),
+		}
+		return
+	}
+}
+
+func SaveSimulRouteValidator(SaveRoutes http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var s simulRouteValidator
+		s.checkHTTPMethod(req)
+		//convertJSONToStructの第２引数はinterfaceなので、変数を宣言してポインタを渡す必要がある
+		var reqFields model.SimulRoute
+		s.convertJSONToStruct(req, &reqFields)
+		s.checkContainedChar(reqFields.Title)
+
+		if s.err != nil {
+			e := s.err.(customerr.BaseErr)
+			http.Error(w, e.Msg, http.StatusBadRequest)
+			log.Printf("operation: %s, error: %v", e.Op, e.Err)
+			return
+		}
+
+		//contextに各フィールドの値を追加
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, "simulRouteFields", reqFields)
+		SaveRoutes.ServeHTTP(w, req.WithContext(ctx))
+	}
+}
+
+//func UpdateSimulRouteValidator(UpdateRoute http.HandlerFunc) http.HandlerFunc {
+//	return func(w http.ResponseWriter, req *http.Request) {
+//		var s simulRouteValidator
+//		controllers.CheckHTTPMethod(req, &s.err)
+//		//convertJSONToStructの第２引数はinterfaceなので、変数を宣言してポインタを渡す必要がある
+//		var reqFields multiroute.RouteUpdateRequest
+//		s.convertJSONToStruct(req, &reqFields)
+//		s.checkContainedChar(reqFields.Title)
+//
+//		if s.err != nil {
+//			e := s.err.(customerr.BaseErr)
+//			http.Error(w, e.Msg, http.StatusBadRequest)
+//			log.Printf("operation: %s, error: %v", e.Op, e.Err)
+//			return
+//		}
+//
+//		//contextに各フィールドの値を追加
+//		ctx := req.Context()
+//		ctx = context.WithValue(ctx, "reqFields", reqFields)
+//		UpdateRoute.ServeHTTP(w, req.WithContext(ctx))
+//	}
+//}

--- a/app/templates/simul_search/simul_search.html
+++ b/app/templates/simul_search/simul_search.html
@@ -15,31 +15,44 @@
 <body>
 {{ template "navbar" .}}
 <form action="/do_simul_search" method="POST">
-    <div class="origin px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
-        <h3>出発地</h3>
-        <div class="mode-selector">
-            <input placeholder="出発地を入力" id="origin-input" name="origin-input" style="width: 50%;"><br>
-            <small>選択肢の中からお選びください</small><br>
-            <input type="radio" name="route-option" id="walking" value="walking" checked="checked">
-            <label class="mr-1" for="walking">徒歩</label>
-            <input type="radio" name="route-option" id="transit" value="transit">
-            <label for="transit">公共交通機関</label>
-            <input type="radio" name="route-option" id="driving" value="driving">
-            <label for="driving">自動車</label>
+    <div class="container row mx-auto">
+        <div class="col-2"></div>
+        <div class="col-8 origin px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
+            <h3>出発地</h3>
+            <div class="mode-selector">
+                <div class="row">
+                    <div class="col-3"></div>
+                    <div class="col-6 pr-0">
+                        <input placeholder="出発地を入力" id="origin-input" name="origin-input" style="width: 100%;"><br>
+                    </div>
+                    <div class="col-3 text-left">
+                        <button type="button" id="simul-search" class="btn-success" style="font-size: 18px">同時検索
+                        </button>
+                    </div>
+                </div>
+                <small>選択肢の中からお選びください</small><br>
+                <input type="radio" name="route-option" id="walking" value="walking" checked="checked">
+                <label class="mr-1" for="walking">徒歩</label>
+                <input type="radio" name="route-option" id="transit" value="transit">
+                <label for="transit">公共交通機関</label>
+                <input type="radio" name="route-option" id="driving" value="driving">
+                <label for="driving">自動車</label>
+            </div>
+            <div class="departure-time" id="departure-time" style="display: none">
+                <input type="radio" id="set-now" name="time-option" checked="checked">
+                <label class="mr-2" for="set-now">すぐに出発</label>
+                <input type="radio" id="set-future" name="time-option">
+                <label class="mr-2" for="set-future">出発時間</label>
+                <input type="date" id="date">
+                <input type="time" id="time">
+            </div>
+            <div class="driving-option" id="driving-option" style="display: none">
+                <input type="checkbox" name="driving-option-select" id="avoid-tolls"/>有料道路を使用しない
+                <br>
+                <input type="checkbox" name="driving-option-select" id="avoid-highways"/>高速道路を使用しない
+            </div>
         </div>
-        <div class="departure-time" id="departure-time" style="display: none">
-            <input type="radio" id="set-now" name="time-option" checked="checked">
-            <label class="mr-2" for="set-now">すぐに出発</label>
-            <input type="radio" id="set-future" name="time-option">
-            <label class="mr-2" for="set-future">出発時間</label>
-            <input type="date" id="date">
-            <input type="time" id="time">
-        </div>
-        <div class="driving-option" id="driving-option" style="display: none">
-            <input type="checkbox" name="driving-option-select" id="avoid-tolls"/>有料道路を使用しない
-            <br>
-            <input type="checkbox" name="driving-option-select" id="avoid-highways"/>高速道路を使用しない
-        </div>
+        <div class="col-2"></div>
     </div>
 
     <div class="container">
@@ -65,10 +78,23 @@
             </div>
             {{end}}
         </div>
-        <div class="mb-3 mx-auto text-center">
-            <button type="button" id="simul-search" class="btn-success" style="font-size: 18px">同時検索を実行</button>
-        </div>
+
     </div>
 </form>
+<div class="container row mx-auto mt-2 pb-5">{{if .isLoggedIn}}
+    <div class="col-3"></div>
+    <div class="col-6 text-right">
+        <span class="ml-2" style="color: black">検索結果の保存:</span>
+        <input type="text" id="route-title" style="width: 350px"
+               placeholder="保存するタイトルを入力(.,$以外の文字)"><br>
+    </div>
+    <div class="col-3 pl-0">
+        <input type="button" class="btn-info" id="save-route" value="ルートを保存">
+    </div>
+    {{else}}
+    <span style="color:grey;">新規登録していただくと検索結果の保存ができます。</span><br>
+    <a href="/register_form">新規登録はこちらから</a>
+    {{end}}
+</div>
 </body>
 </html>


### PR DESCRIPTION
1: multirouteと同様のプロセスで、simulsearchも検索結果を保存出来るよう機能追加
2: simulsearchのAPIからのレスポンスをslice形式ではなく、modelのSimulRouteのstructにすることで、フロントエンド側で扱いやすいように変更