### PR TITLE
保存した同時検索の表示機能追加

### DIFF
--- a/app/controllers/mypage/show_titles.go
+++ b/app/controllers/mypage/show_titles.go
@@ -57,3 +57,38 @@ func getRouteTitles(userID primitive.ObjectID) []string {
 
 	return titleNames
 }
+
+func getSimulRouteTitles(userID primitive.ObjectID) []string {
+	b, err := model.FindUser("_id", userID)
+	if err != nil {
+		return []string{}
+	}
+	titlesM := b["simul_route_titles"].(primitive.M) //bson M型 (map[string]interface{})
+
+	var titles = make(map[string]time.Time)
+	for title, tStamp := range titlesM {
+		t, ok := tStamp.(primitive.DateTime)
+		if !ok {
+			log.Println("Assertion error at checking timestamp type")
+			return []string{}
+		}
+		timeStamp := t.Time() //time.Time型に変換
+		titles[title] = timeStamp
+	}
+
+	tSlice := make(TitileSlice, len(titles))
+	i := 0
+	for k, v := range titles {
+		tSlice[i] = TitleMap{k, v}
+		i++
+	}
+	//保存日時順にソート
+	sort.Sort(tSlice)
+	//タイトル名を入れるsliceを作成
+	titleNames := make([]string, 0, len(titles))
+	for _, tMap := range tSlice {
+		titleNames = append(titleNames, tMap.TitleName)
+	}
+
+	return titleNames
+}

--- a/app/controllers/mypage/tpl_handler.go
+++ b/app/controllers/mypage/tpl_handler.go
@@ -118,3 +118,33 @@ func ShowQuestionForm(w http.ResponseWriter, req *http.Request) {
 	t.data["email"] = t.user.Email
 	mypageTpl.ExecuteTemplate(w, "question_form.html", t.data)
 }
+
+func ShowAllSimulRoutes(w http.ResponseWriter, req *http.Request) {
+	var t tplProcess
+	t.data = contexthandler.GetLoginStateFromCtx(req)
+	contexthandler.GetUserFromCtx(req, &t.user, &t.err)
+	if t.err != nil {
+		e := t.err.(customerr.BaseErr)
+		cookiehandler.MakeCookieAndRedirect(w, req, "msg", e.Msg, "/mypage")
+		log.Printf("operation: %s, error: %v", e.Op, e.Err)
+		return
+	}
+	titleNames := getSimulRouteTitles(t.user.ID)
+	t.data["userName"] = t.user.UserName
+	t.data["titles"] = titleNames
+
+	//successメッセージがある場合
+	c, err := req.Cookie("success")
+	if err == nil {
+		processCookie(w, c, t.data, "show_simul_routes.html")
+		return
+	}
+	//エラーメッセージがある場合
+	c, err = req.Cookie("msg")
+	if err == nil {
+		processCookie(w, c, t.data, "show_simul_routes.html")
+		return
+	}
+
+	mypageTpl.ExecuteTemplate(w, "show_simul_routes.html", t.data)
+}

--- a/app/controllers/simulsearch/show_route.go
+++ b/app/controllers/simulsearch/show_route.go
@@ -1,0 +1,95 @@
+package simulsearch
+
+import (
+	"app/bsonconv"
+	"app/contexthandler"
+	"app/cookiehandler"
+	"app/customerr"
+	"app/model"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var showRouteTpl *template.Template
+
+func init() {
+	showRouteTpl = template.Must(template.Must(template.ParseGlob("templates/simul_search/show_and_edit/simul_search_show.html")).ParseGlob("templates/includes/*.html"))
+}
+
+type editRoute struct {
+	user       model.User
+	routeModel model.SimulRoute
+	routeJSON  string
+	err        error
+}
+
+//getRouteFromDB gets route document from DB
+func (eR *editRoute) getRouteFromDB(title string) bson.M {
+	if eR.err != nil {
+		return nil
+	}
+	d, err := model.FindSimulRoute(eR.user.ID, title)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			eR.err = customerr.BaseErr{
+				Op:  "Finding simul route document",
+				Msg: "ご指定いただいたルートがありません。",
+				Err: fmt.Errorf("error while finding route document from routes collection: %w", err),
+			}
+			return nil
+		} else {
+			eR.err = customerr.BaseErr{
+				Op:  "Finding route document",
+				Msg: "エラーが発生しました。",
+				Err: fmt.Errorf("error while finding route document from routes collection: %w", err),
+			}
+			return nil
+		}
+	}
+	return d
+}
+
+//convertStructToJSON makes JSON object from simulRoute struct
+func (eR *editRoute) convertStructToJSON() {
+	if eR.err != nil {
+		return
+	}
+	//レスポンス作成
+	jsonEnc, err := json.Marshal(eR.routeModel)
+	if err != nil {
+		eR.err = customerr.BaseErr{
+			Op:  "json marshaling simulRoute struct",
+			Msg: "エラーが発生しました。",
+			Err: fmt.Errorf("error while json marshaling: %w", err),
+		}
+		return
+	}
+	//JSONのバイナリ形式のままだとtemplateで読み込めないので、stringに変換
+	eR.routeJSON = string(jsonEnc)
+}
+
+func ShowAndEditSimulRoutesTpl(w http.ResponseWriter, req *http.Request) {
+	var eR editRoute
+	contexthandler.GetUserFromCtx(req, &eR.user, &eR.err)
+	routeTitle := req.URL.Query().Get("route_title")
+	d := eR.getRouteFromDB(routeTitle)
+	bsonconv.ConvertDucToStruct(d, &eR.routeModel, &eR.err, "simul route")
+	eR.convertStructToJSON()
+	if eR.err != nil {
+		e := eR.err.(customerr.BaseErr)
+		cookiehandler.MakeCookieAndRedirect(w, req, "msg", e.Msg, "/mypage/simul_search/show_routes")
+		log.Printf("operation: %s, error: %v", e.Op, e.Err)
+		return
+	}
+	data := contexthandler.GetLoginStateFromCtx(req)
+	data["routeInfo"] = eR.routeJSON
+	nineIterator := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	data["nineIterator"] = nineIterator
+	showRouteTpl.ExecuteTemplate(w, "simul_search_show.html", data)
+}

--- a/app/main.go
+++ b/app/main.go
@@ -51,13 +51,15 @@ func main() {
 	http.HandleFunc("/simul_search", middleware.Auth(simulsearch.SimulSearchTpl))                                                 //検索画面
 	http.HandleFunc("/do_simul_search", reqvalidator.SimulSearchValidator(simulsearch.DoSimulSearch))                             //検索実行用エンドポイント
 	http.HandleFunc("/simul_search/routes_save", middleware.Auth(reqvalidator.SaveSimulRouteValidator(simulsearch.SaveNewRoute))) //保存用エンドポイント
+	http.HandleFunc("/simul_search/show_route/", middleware.Auth(simulsearch.ShowAndEditSimulRoutesTpl))                          //
 
 	//「マイページ」
-	http.HandleFunc("/mypage", middleware.Auth(mypage.ShowMypage))                 //マイページ表示
-	http.HandleFunc("/mypage/show_routes", middleware.Auth(mypage.ShowAllRoutes))  //保存したルート一覧
-	http.HandleFunc("/mypage/delete_route", middleware.Auth(mypage.ConfirmDelete)) //削除確認
-	http.HandleFunc("/question_form", middleware.Auth(mypage.ShowQuestionForm))    //お問い合わせ入力ページ
-	http.HandleFunc("/send_question", middleware.Auth(mailhandler.SendQuestion))   //お問い合わせ送信用エンドポイント
+	http.HandleFunc("/mypage", middleware.Auth(mypage.ShowMypage))                                  //マイページ表示
+	http.HandleFunc("/mypage/show_routes", middleware.Auth(mypage.ShowAllRoutes))                   //保存したルート一覧
+	http.HandleFunc("/mypage/simul_search/show_routes", middleware.Auth(mypage.ShowAllSimulRoutes)) //保存した同時検索一覧
+	http.HandleFunc("/mypage/delete_route", middleware.Auth(mypage.ConfirmDelete))                  //削除確認
+	http.HandleFunc("/question_form", middleware.Auth(mypage.ShowQuestionForm))                     //お問い合わせ入力ページ
+	http.HandleFunc("/send_question", middleware.Auth(mailhandler.SendQuestion))                    //お問い合わせ送信用エンドポイント
 
 	//「プロフィール」
 	http.HandleFunc("/profile/username_edit_form", middleware.Auth(profile.EditUserNameForm)) //プロフィール画面

--- a/app/templates/mypage/mypage.html
+++ b/app/templates/mypage/mypage.html
@@ -20,12 +20,12 @@
     <div class="row card-deck mb-1 text-center">
         <div class="col-md-4 mb-5 shadow-sm">
             <div class="card">
-                <div class="card-header" style="background-color: #1A73E8">
+                <div class="card-header" style="background-color: orange">
                     <h4 class="my-0 font-weight-normal" style="color: white">プロフィール</h4>
                 </div>
                 <div class="card-body">
                     <a href="/profile">
-                    <button class="btn-success" type="button">確認または編集</button>
+                    <button class="text-white btn-warning" type="button">確認または編集</button>
                     </a>
                 </div><!-- card-body end .// -->
             </div><!-- card end.// -->
@@ -33,23 +33,35 @@
         <div class="col-md-4 mb-5 shadow-sm">
             <div class="card">
                 <div class="card-header" style="background-color: #1A73E8">
-                    <h4 class="my-0 font-weight-normal" style="color: white">保存したルート一覧</h4>
+                    <h4 class="my-0 font-weight-normal" style="color: white">保存したまとめ検索一覧</h4>
                 </div>
                 <div class="card-body">
                     <a href="/mypage/show_routes">
-                        <button class="btn-success" type="button">保存したルートを確認</button>
+                        <button class="btn-primary" type="button">保存したルートを確認</button>
                     </a>
                 </div><!-- card-body end .// -->
             </div><!-- card end.// -->
         </div>
         <div class="col-md-4 mb-5 shadow-sm">
             <div class="card">
-                <div class="card-header" style="background-color: #1A73E8">
+                <div class="card-header" style="background-color: #0dcaf0">
+                    <h4 class="my-0 font-weight-normal" style="color: white">保存した同時検索一覧</h4>
+                </div>
+                <div class="card-body">
+                    <a href="/mypage/simul_search/show_routes">
+                        <button class="btn-info" type="button">保存したルートを確認</button>
+                    </a>
+                </div><!-- card-body end .// -->
+            </div><!-- card end.// -->
+        </div>
+        <div class="col-md-4 mb-5 shadow-sm">
+            <div class="card">
+                <div class="card-header" style="background-color: #6c757d">
                     <h4 class="my-0 font-weight-normal" style="color: white">お問い合わせ</h4>
                 </div>
                 <div class="card-body">
                     <a href="/question_form">
-                        <button class="btn-success" type="button">質問する</button>
+                        <button class="btn-secondary" type="button">質問する</button>
                     </a>
                 </div><!-- card-body end .// -->
             </div><!-- card end.// -->

--- a/app/templates/mypage/show_simul_routes.html
+++ b/app/templates/mypage/show_simul_routes.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<head>
+    <meta charset="UTF-8">
+    <title>保存済みルート一覧</title>
+    {{ template "imports" }}
+
+</head>
+<body>
+{{ template "navbar" .}}
+{{if .msg}}
+<div class="py-2 d-flex" style="background-color: pink"><span class="mx-auto" style="color: brown">{{.msg}}</span></div>
+{{else if .success}}
+<div class="py-2 d-flex" style="background-color: lightblue"><span class="mx-auto"
+                                                                   style="color: green">{{.success}}</span></div>
+{{end}}
+<div class="mt-5 text-center">
+    <h3>{{.userName}}さんが保存したルート</h3>
+</div>
+<div class="container">
+    <hr>
+    <div class="row card-deck mb-1 text-center">
+        {{range $_, $title := .titles}}
+        <div class="col-md-4 mb-5 shadow-sm">
+            <div class="card">
+                <div class="card-header" style="background-color: #1A73E8">
+                    <h4 class="my-0 font-weight-normal" style="color: white">{{$title}}</h4>
+                </div>
+                <div class="card-body">
+                    <a href="/simul_search/show_route/?route_title={{$title}}">
+                        <button class="btn-success" type="button">確認または編集</button>
+                    </a>
+                    <hr>
+                    <form action="/mypage/simul_search/delete_route" method="POST">
+                        <button class="btn-danger" type="submit" name="title" value="{{$title}}">削除する</button>
+                    </form>
+                </div><!-- card-body end .// -->
+            </div><!-- card end.// -->
+        </div>
+        {{end}}
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/app/templates/simul_search/show_and_edit/simul_search_show.css
+++ b/app/templates/simul_search/show_and_edit/simul_search_show.css
@@ -1,0 +1,21 @@
+html {
+    font-size: 14px;
+}
+
+@media (min-width: 768px) {
+    html {
+        font-size: 16px;
+    }
+}
+
+.container {
+    max-width: 1200px;
+}
+
+.origin {
+    max-width: 700px;
+}
+
+.card-deck .card {
+    min-width: 220px;
+}

--- a/app/templates/simul_search/show_and_edit/simul_search_show.html
+++ b/app/templates/simul_search/show_and_edit/simul_search_show.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<head>
+    <title>9地点同時検索</title>
+    {{ template "imports" }}
+    <!--読み込んだルートのJSONをrouteInfoに入れる-->
+    <script>routeInfo = JSON.parse(
+        {{.routeInfo}});
+    </script>
+    <!--CSS-->
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/templates/simul_search/show_and_edit/simul_search_show.css">
+
+    <!--Javascript-->
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
+
+    <script src="/templates/simul_search/show_and_edit/simul_search_show.js"></script>
+</head>
+
+<body>
+{{ template "navbar" .}}
+<form action="/do_simul_search" method="POST">
+    <div class="container row mx-auto">
+        <div class="col-2"></div>
+        <div class="col-8 origin px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
+            <h3>出発地</h3>
+            <div class="mode-selector">
+                <div class="row">
+                    <div class="col-3"></div>
+                    <div class="col-6 pr-0">
+                        <input placeholder="出発地を入力" id="origin-input" name="origin-input" style="width: 100%;"><br>
+                    </div>
+                    <div class="col-3 text-left">
+                        <button type="button" id="simul-search" class="btn-success" style="font-size: 18px">同時検索
+                        </button>
+                    </div>
+                </div>
+                <small>選択肢の中からお選びください</small><br>
+                <input type="radio" name="route-option" id="walking" value="walking" checked="checked">
+                <label class="mr-1" for="walking">徒歩</label>
+                <input type="radio" name="route-option" id="transit" value="transit">
+                <label for="transit">公共交通機関</label>
+                <input type="radio" name="route-option" id="driving" value="driving">
+                <label for="driving">自動車</label>
+            </div>
+            <div class="departure-time" id="departure-time" style="display: none">
+                <input type="radio" id="set-now" name="time-option" checked="checked">
+                <label class="mr-2" for="set-now">すぐに出発</label>
+                <input type="radio" id="set-future" name="time-option">
+                <label class="mr-2" for="set-future">出発時間</label>
+                <input type="date" id="date">
+                <input type="time" id="time">
+            </div>
+            <div class="driving-option" id="driving-option" style="display: none">
+                <input type="checkbox" name="driving-option-select" id="avoid-tolls"/>有料道路を使用しない
+                <br>
+                <input type="checkbox" name="driving-option-select" id="avoid-highways"/>高速道路を使用しない
+            </div>
+        </div>
+        <div class="col-2"></div>
+    </div>
+
+    <div class="container">
+        <hr>
+        <div class="row card-deck mb-1 text-center">
+            {{range $_, $route_num := .nineIterator}}
+            <div class="col-md-4 mb-3 shadow-sm">
+                <div class="card">
+                    <div class="card-header" style="background-color: #1A73E8">
+                        <h4 class="my-0 font-weight-normal" style="color: white">目的地{{$route_num}}</h4>
+                    </div>
+                    <div class="card-body">
+                        <input id="destination-input{{$route_num}}" name="destination-input{{$route_num}}"
+                               placeholder="目的地{{$route_num}}を入力">
+                        <ul class="list-unstyled mt-3 mb-2">
+                            <li>目的地までの距離:</li>
+                            <li id="distance{{$route_num}}"></li>
+                            <li>目的地までの所要時間:</li>
+                            <li id="duration{{$route_num}}" style="color: coral"></li>
+                        </ul>
+                    </div><!-- card-body end .// -->
+                </div><!-- card end.// -->
+            </div>
+            {{end}}
+        </div>
+
+    </div>
+</form>
+<div class="container row mx-auto mt-2 pb-5">{{if .isLoggedIn}}
+    <div class="col-3"></div>
+    <div class="col-6 text-right">
+        <span class="ml-2" style="color: black">検索結果の保存:</span>
+        <input type="text" id="route-title" style="width: 350px"
+               placeholder="保存するタイトルを入力(.,$以外の文字)"><br>
+    </div>
+    <div class="col-3 pl-0">
+        <input type="button" class="btn-info" id="save-route" value="ルートを保存">
+    </div>
+    {{else}}
+    <span style="color:grey;">新規登録していただくと検索結果の保存ができます。</span><br>
+    <a href="/register_form">新規登録はこちらから</a>
+    {{end}}
+</div>
+</body>
+</html>

--- a/app/templates/simul_search/show_and_edit/simul_search_show.js
+++ b/app/templates/simul_search/show_and_edit/simul_search_show.js
@@ -1,0 +1,279 @@
+var searchResult = {
+  title: "",
+  simul_routes:{},
+}
+
+const simulSearchUpdateReq = Object.assign({}, routeInfo);
+
+//検索結果保存
+$(function () {
+  $("#save-route").click(function () {
+    var keys = Object.keys(searchResult.simul_routes);
+    if (keys.length === 0) {
+      window.alert("ルートを１つ以上設定してください。");
+      return;
+    }
+    if ($("#route-title").val() === "") {
+      window.alert("保存名は１文字以上入力してください。");
+      return;
+    }
+    searchResult.title = document.getElementById("route-title").value;
+    if (/[\.\$]/.test(document.getElementById("route-title").value)) {
+      window.alert(".または$はタイトル名に使用できません。");
+      return;
+    }
+    // 多重送信を防ぐため通信完了までボタンをdisableにする
+    var button = $(this);
+    button.attr("disabled", true);
+
+    $.ajax({
+      url: "/simul_search/routes_save", // 通信先のURL
+      type: "POST", // 使用するHTTPメソッド
+      data: JSON.stringify(searchResult),
+      contentType: "application/json",
+      dataType: "json", // responseのデータの種類
+      timespan: 1000, // 通信のタイムアウトの設定(ミリ秒)
+    })
+        //通信成功
+        .done(function (data, textStatus, jqXHR) {
+          window.location.href = "/simul_search";
+          //通信失敗
+        })
+        .fail(function (xhr, status, error) {
+          // HTTPエラー時
+          switch (xhr.status) {
+            case 401:
+              alert(xhr.responseText);
+              break;
+            case 500:
+              alert(xhr.responseText);
+          }
+
+          //通信終了後
+        })
+        .always(function (arg1, status, arg2) {
+          //status が "success" の場合は always(data, status, xhr) となるが
+          //、"success" 以外の場合は always(xhr, status, error)となる。
+          button.attr("disabled", false); // ボタンを再び enableにする
+        });
+  });
+});
+
+
+//Ajax通信
+$(function () {
+  $("#simul-search").click(function () {
+    // 多重送信を防ぐため通信完了までボタンをdisableにする
+    var button = $(this);
+    button.attr("disabled", true);
+
+    //公共交通機関選択の場合
+    if (
+      document.getElementById("transit").checked &&
+      document.getElementById("set-future").checked
+    ) {
+      simulReq["mode"] = "transit";
+      simulReq["departure_time"] =
+        document.getElementById("date").value +
+        "T" +
+        document.getElementById("time").value;
+    }
+    //自動車選択の場合
+    else if (document.getElementById("driving").checked) {
+      var tmparr = [];
+      if (document.getElementById("avoid-tolls").checked) {
+        tmparr.push("tolls");
+      }
+      if (document.getElementById("avoid-highways").checked) {
+        tmparr.push("highways");
+      }
+      simulReq["avoid"] = tmparr;
+    }
+
+    $.ajax({
+      url: "/do_simul_search", // 通信先のURL
+      type: "POST", // 使用するHTTPメソッド
+      data: JSON.stringify(simulReq),
+      contentType: "application/json",
+      dataType: "json", // responseのデータの種類
+      timespan: 2000, // 通信のタイムアウトの設定(ミリ秒)
+      //通信成功
+    })
+      .done(function (simulSearchResult, textStatus, jqXHR) {
+        searchResult.simul_routes = simulSearchResult;
+        for (var i = 1; i < 10; i++) {
+          if (simulSearchResult[i]) {
+            document.getElementById("distance" + String(i)).innerText =
+              simulSearchResult[i].distance;
+            document.getElementById("duration" + String(i)).innerText =
+              simulSearchResult[i].duration;
+          }
+        }
+        //通信失敗
+      })
+      .fail(function (xhr, status, error) {
+        // HTTPエラー時
+        switch (xhr.status) {
+          case 400:
+            alert(xhr.responseText);
+            break;
+          case 500:
+            alert(xhr.responseText);
+        }
+        //通信終了後
+      })
+      .always(function (arg1, status, arg2) {
+        //status が "success" の場合は always(data, status, xhr) となるが
+        //、"success" 以外の場合は always(xhr, status, error)となる。
+        button.attr("disabled", false); // ボタンを再び enableにする
+      });
+  });
+});
+
+var simulReq = {
+  origin: "",
+  destinations: {
+    1: "",
+    2: "",
+    3: "",
+    4: "",
+    5: "",
+    6: "",
+    7: "",
+    8: "",
+    9: "",
+  },
+  mode: "",
+  departure_time: "",
+  latlng: { lat: "", lng: "" },
+  avoid: [],
+};
+//現在時刻を取得し、時間指定要素に挿入
+var today = new Date();
+var yyyy = today.getFullYear();
+var mm = ("0" + (today.getMonth() + 1)).slice(-2); //getMonthは0 ~ 11
+var dd = ("0" + today.getDate()).slice(-2);
+var ymd = yyyy + "-" + mm + "-" + dd;
+var hr = ("0" + today.getHours()).slice(-2);
+var minu = ("0" + today.getMinutes()).slice(-2);
+var clock = hr + ":" + minu + ":00";
+
+
+//Google Maps API実行ファイル読み込み
+window.onload = function () {
+  fetch("/get_api_source")
+      .then((resp) => {
+        return resp.text();
+      })
+      .then((MapJS) => {
+        window.Function(MapJS)(); //ファイル実行
+        initAutocomplete(); //APIリクエストのcallbackではなくここで実行
+      })
+      .catch(() => {
+        alert("エラーが発生しました。");
+      });
+};
+//出発地と目的地の自動入力を設定
+function initAutocomplete() {
+  // 日付を設定
+  document.getElementById("date").value = ymd;
+  document.getElementById("date").min = ymd;
+  document.getElementById("time").value = clock;
+
+  var originInput = document.getElementById("origin-input");
+  const originAutocomplete = new google.maps.places.Autocomplete(originInput);
+  //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
+  originAutocomplete.setFields(["place_id", "geometry", "formatted_address"]);
+  originAutocomplete.addListener("place_changed", () => {
+    const place = originAutocomplete.getPlace();
+    if (!place.place_id) {
+      window.alert("表示された選択肢の中から選んでください。");
+    } else if (
+      document.getElementById("transit").checked &&
+      place.formatted_address.indexOf("日本") !== -1
+    ) {
+      window.alert(
+        "日本の公共交通機関情報はGoogle Maps APIの仕様上、ご利用いただけません。"
+      );
+      return;
+    }
+    simulReq["origin"] = place.place_id;
+    simulReq["latlng"]["lat"] = String(place.geometry.location.lat());
+    simulReq["latlng"]["lng"] = String(place.geometry.location.lng());
+  });
+  //目的地検索のAutocompleteを有効化
+  for (var i = 1; i < 10; i++) {
+    new AutocompleteHandler(String(i));
+  }
+  document
+    .getElementById("walking")
+    .addEventListener("click", setupClickListener);
+  document
+    .getElementById("transit")
+    .addEventListener("click", setupClickListener);
+  document
+    .getElementById("driving")
+    .addEventListener("click", setupClickListener);
+}
+
+//経路オプションのラジオボタンが押されたら発火
+function setupClickListener() {
+  if (this.id === "transit") {
+    if (document.getElementById("origin-input").value.indexOf("日本") !== -1) {
+      window.alert(
+        "日本の公共交通機関情報はGoogle Maps APIの仕様上、ご利用いただけません。"
+      );
+      return;
+    }
+    document.getElementById("departure-time").style.display = "block";
+  } else if (this.id !== "transit") {
+    document.getElementById("departure-time").style.display = "none";
+  }
+  if (this.id === "driving") {
+    document.getElementById("driving-option").style.display = "block";
+  } else if (this.id !== "driving") {
+    document.getElementById("driving-option").style.display = "none";
+  }
+  simulReq.mode = this.value;
+}
+
+//目的地検索のAutocompleteを設定
+class AutocompleteHandler {
+  constructor(routeNum) {
+    this.routeNum = routeNum;
+    const destinationInput = document.getElementById(
+      "destination-input" + routeNum
+    );
+    const destinationAutocomplete = new google.maps.places.Autocomplete(
+      destinationInput
+    );
+    //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
+    destinationAutocomplete.setFields([
+      "place_id",
+      "geometry",
+      "formatted_address",
+    ]);
+    //EventListenerの設定
+    this.setupPlaceChangedListener(destinationAutocomplete);
+  }
+
+  //目的地の入力があった場合、発火
+  setupPlaceChangedListener(autocomplete) {
+    autocomplete.addListener("place_changed", () => {
+      const place = autocomplete.getPlace();
+      if (!place.place_id) {
+        window.alert("表示された選択肢の中から選んでください。");
+        return;
+      } else if (
+        document.getElementById("transit").checked &&
+        place.formatted_address.indexOf("日本") !== -1
+      ) {
+        window.alert(
+          "日本の公共交通機関情報はGoogle Maps APIの仕様上、ご利用いただけません。"
+        );
+        return;
+      }
+      simulReq["destinations"][this.routeNum] = place.place_id;
+    });
+  }
+}


### PR DESCRIPTION
1: マイページから保存した同時検索の一覧表示および各同時検索の表示機能追加
2: 表示した同時検索ではまだ編集機能は実装していないため追加が必要
3: 同時検索の保存時DBにはdestinationとしてAPIに用いるplace_idが保存されているが、編集時に住所が表示されていないとわかりにくいため、DBにdestination_adressフィールドを追加して編集時に住所表示をできるようにしたい