### PR TITLE
まとめ検索の画面に用いるJavascriptファイルのリファクタリング

### DIFF
--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -658,12 +658,7 @@ class AutocompleteDirectionsHandler {
           routePolyline.setPath(response.routes[i].overview_path);
 
           //
-          routePolyline.setOptions({
-            clickable: true,
-            strokeColor: "#808080", //線の色
-            strokeOpacity: 0.5, //線の透明度
-            strokeWeight: 7, //線の太さ
-          });
+          routePolyline.setOptions(optionsForAlternatives(me.routeNum));
           routePolyline.setMap(me.map);
           me.poly.push(routePolyline);
 
@@ -671,12 +666,7 @@ class AutocompleteDirectionsHandler {
           me.poly[i].addListener("click", callback);
         }
         //インデックス番号0のルートに色をつける
-        me.poly[0].setOptions({
-          clickable: true,
-          strokeColor: me.colorCode, //線の色
-          strokeOpacity: 0.5, //線の透明度
-          strokeWeight: 7, //線の太さ
-        });
+        me.poly[0].setOptions(optionsForSelected(me.routeNum));
         me.directionsRenderer.setRouteIndex(0);
 
         //responseをRendererに渡して、パネルにルートを表示

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -211,6 +211,33 @@ const AUTO_COMPLETE_FIELDS = [
     "utc_offset_minutes",
     ]
 
+const defaultPolyLineOptions = {
+  clickable: true,
+  //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
+  //元に戻すためには、全てのルートについて#808080に設定する必要あり。)
+  strokeColor: "#808080",
+  strokeOpacity: 0.7,
+  strokeWeight: 7,
+}
+
+function optionsForAlternatives(zIndex) {
+  let polyLineOptions = Object.assign({}, defaultPolyLineOptions);
+  polyLineOptions.zIndex =  parseInt(zIndex);
+  return polyLineOptions;
+}
+
+function optionsForSelected(strokeColor, zIndex) {
+  let selectedPolyLine = Object.assign({}, defaultPolyLineOptions);
+  //選択したルートの色をcolorCodeに従って変更
+  selectedPolyLine.strokeColor = strokeColor;
+  selectedPolyLine.strokeOpacity = 1.0;
+  //色付きラインを一番上に表示するため、zIndexを大きくする
+  selectedPolyLine.zIndex = parseInt(zIndex) + 1;
+  return selectedPolyLine;
+}
+
+
+
 class AutocompleteDirectionsHandler {
   constructor(map, routeNum) {
     /**
@@ -374,26 +401,9 @@ class AutocompleteDirectionsHandler {
       var target = directionsRenderer.getRouteIndex();
       for (var i = 0; i < obj.poly.length; i++) {
         if (i == target) {
-          obj.poly[i].setOptions({
-            //選択したルートの場合、色をcolorCodeに従って変更
-            clickable: true,
-            strokeColor: obj.colorCode,
-            strokeOpacity: 1.0,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを他のルートより大きくする。
-            zIndex: parseInt(obj.routeNum) + 1,
-          });
+          obj.poly[i].setOptions(optionsForSelected(obj.colorCode, obj.routeNum));
         } else {
-          obj.poly[i].setOptions({
-            //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
-            //元に戻すためには、全てのルートについて#808080に設定する必要あり。)
-            clickable: true,
-            strokeColor: "#808080",
-            strokeOpacity: 0.7,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを小さくする
-            zIndex: parseInt(obj.routeNum),
-          });
+          obj.poly[i].setOptions(optionsForAlternatives(obj.routeNum));
         }
         obj.poly[i].setMap(obj.map);
       }
@@ -506,26 +516,9 @@ class AutocompleteDirectionsHandler {
       me.directionsRenderer.setRouteIndex(idx);
       for (var j = 0; j < me.poly.length; j++) {
         if (j == idx) {
-          me.poly[j].setOptions({
-            //選択したルートの場合、色をcolorCodeに従って変更
-            clickable: true,
-            strokeColor: me.colorCode,
-            strokeOpacity: 1.0,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを他のルートより大きくする。
-            zIndex: parseInt(me.routeNum) + 1,
-          });
+          me.poly[j].setOptions(optionsForSelected(me.colorCode, me.routeNum));
         } else {
-          me.poly[j].setOptions({
-            //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
-            //元に戻すためには、全てのルートについて#808080に設定する必要あり。
-            clickable: true,
-            strokeColor: "#808080",
-            strokeOpacity: 0.7,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを小さくする
-            zIndex: parseInt(me.routeNum),
-          });
+          me.poly[j].setOptions(optionsForAlternatives(me.routeNum));
         }
         me.poly[j].setMap(me.map);
       }

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -201,6 +201,16 @@ class Elements {
     }
 }
 
+
+const MSG_CANNOT_USE_IN_JAPAN = "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。" +
+                                "海外の公共交通機関情報はご利用いただけます。"
+const AUTO_COMPLETE_FIELDS = [
+    "place_id",
+    "geometry",
+    "formatted_address",
+    "utc_offset_minutes",
+    ]
+
 class AutocompleteDirectionsHandler {
   constructor(map, routeNum) {
     /**
@@ -242,22 +252,12 @@ class AutocompleteDirectionsHandler {
 
     const originAutocomplete = new google.maps.places.Autocomplete(this.elements.originInput);
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
-    originAutocomplete.setFields([
-      "place_id",
-      "geometry",
-      "formatted_address",
-      "utc_offset_minutes",
-    ]);
+    originAutocomplete.setFields(AUTO_COMPLETE_FIELDS);
     const destinationAutocomplete = new google.maps.places.Autocomplete(
       this.elements.destinationInput
     );
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
-    destinationAutocomplete.setFields([
-      "place_id",
-      "geometry",
-      "formatted_address",
-      "utc_offset_minutes",
-    ]);
+    destinationAutocomplete.setFields(AUTO_COMPLETE_FIELDS);
 
     //EventListenerの設定
     this.setupClickListener(
@@ -326,9 +326,7 @@ class AutocompleteDirectionsHandler {
         me.elements.modeTransit.checked &&
         place.formatted_address.indexOf("日本") !== -1
       ) {
-        window.alert(
-          "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-        );
+        window.alert(MSG_CANNOT_USE_IN_JAPAN);
         return;
       }
       if (mode === "ORIG") {
@@ -554,9 +552,7 @@ class AutocompleteDirectionsHandler {
           .getElementById("origin-input" + me.routeNum)
           .value.indexOf("日本") !== -1
       ) {
-        window.alert(
-          "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-        );
+        window.alert(MSG_CANNOT_USE_IN_JAPAN);
         return;
       }
       this.directionsRequest.transitOptions = {};
@@ -629,9 +625,7 @@ class AutocompleteDirectionsHandler {
         ) {
           document.getElementById("route-decide" + me.routeNum).style.display =
             "none";
-          alert(
-            "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-          );
+          alert(MSG_CANNOT_USE_IN_JAPAN);
           return;
         }
         //複数ルートが帰ってきた場合、それぞれについて、ラインを描画する

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -189,6 +189,10 @@ class Elements {
         this.modeWalking = document.getElementById("changemode-walking" + routeNum);
         this.modeTransit = document.getElementById("changemode-transit" + routeNum);
         this.modeDriving = document.getElementById("changemode-driving" + routeNum);
+
+
+      this.transitOption = document.getElementById("transit-time" + routeNum)
+      this.drivingOption = document.getElementById("driving-option" + routeNum)
     }
 }
 
@@ -293,20 +297,16 @@ class AutocompleteDirectionsHandler {
     const radioButton = document.getElementById(id);
     radioButton.addEventListener("click", () => {
       if (id === this.elements.modeTransit.id) {
-        document.getElementById("transit-time" + this.routeNum).style.display =
+        this.elements.transitOption.style.display =
           "block";
-      } else if (id !== this.elements.modeTransit.id) {
-        document.getElementById("transit-time" + this.routeNum).style.display =
+      } else {
+        this.elements.transitOption.style.display =
           "none";
       }
       if (id === this.elements.modeDriving.id) {
-        document.getElementById(
-          "driving-option" + this.routeNum
-        ).style.display = "block";
+        this.elements.drivingOption.style.display = "block";
       } else if (id !== this.elements.modeDriving.id) {
-        document.getElementById(
-          "driving-option" + this.routeNum
-        ).style.display = "none";
+        this.elements.drivingOption.style.display = "none";
       }
       this.travelMode = mode;
       this.route();

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -1,5 +1,5 @@
 //ルート番号
-var routeID = 0;
+let routeID = 0;
 //ルート描画時の線の色を指定
 const colorMap = {
   0: "#00bfff",
@@ -18,13 +18,13 @@ const multiSearchReq = {
   routes: {},
 };
 // 入力中のルート番号を入れる
-var currRouteNum = "0";
+let currRouteNum = "0";
 
 //Ajax通信
 $(function () {
   $("#save-route").click(function () {
-    var keys = Object.keys(multiSearchReq.routes);
-    if (keys.length == 0) {
+    const keys = Object.keys(multiSearchReq.routes);
+    if (keys.length === 0) {
       window.alert("ルートを１つ以上設定してください。");
       return;
     }
@@ -32,13 +32,13 @@ $(function () {
       window.alert("ルート名は１文字以上入力してください。");
       return;
     }
-    multiSearchReq["title"] = document.getElementById("route-name").value;
     if (/[\.\$]/.test(document.getElementById("route-name").value)) {
       window.alert(".または$はルート名に使用できません。");
       return;
     }
+    multiSearchReq["title"] = document.getElementById("route-name").value;
     // 多重送信を防ぐため通信完了までボタンをdisableにする
-    var button = $(this);
+    const button = $(this);
     button.attr("disabled", true);
 
     $.ajax({
@@ -75,17 +75,17 @@ $(function () {
 });
 
 //現在時刻を取得し、時間指定要素に挿入
-var today = new Date();
-var yyyy = today.getFullYear();
-var mm = ("0" + (today.getMonth() + 1)).slice(-2); //getMonthは0 ~ 11
-var dd = ("0" + today.getDate()).slice(-2);
-var ymd = yyyy + "-" + mm + "-" + dd;
-var hr = ("0" + today.getHours()).slice(-2);
-var minu = ("0" + today.getMinutes()).slice(-2);
-var clock = hr + ":" + minu + ":00";
+let today = new Date();
+let yyyy = today.getFullYear();
+let mm = ("0" + (today.getMonth() + 1)).slice(-2); //getMonthは0 ~ 11
+let dd = ("0" + today.getDate()).slice(-2);
+let ymd = yyyy + "-" + mm + "-" + dd;
+let hr = ("0" + today.getHours()).slice(-2);
+let minu = ("0" + today.getMinutes()).slice(-2);
+let clock = hr + ":" + minu + ":00";
 
 //ブラウザのタイムゾーンのUTCからの時差をminutes単位で取得
-var tzoneOffsetminu = today.getTimezoneOffset();
+let tzoneOffsetminu = today.getTimezoneOffset();
 
 //Google Maps API実行ファイル読み込み
 window.onload = function () {
@@ -105,7 +105,7 @@ window.onload = function () {
 //地図上に路線図と道路状況を表示するlayerの表示制御
 function setUpLayersListener(id,layerController, m) {
   return function () {
-    var layerButton = document.getElementById(id);
+    const layerButton = document.getElementById(id);
     if (!layerButton.checked) {
       layerController.setMap(null);
     } else {
@@ -169,7 +169,7 @@ function initMap() {
   $("#add-route").on("click", function () {
     $("#add-route").attr("disabled", true);
     routeID++;
-    if (routeID == 9) {
+    if (routeID === 9) {
       document.getElementById("add-route").style.display = "none";
     }
     $("#search-box").append(genSearchBox(routeID, colorMap[routeID]));
@@ -211,7 +211,7 @@ class Elements {
       //目的地の入力
       this.destinationInput = document.getElementById("destination-input" + routeNum);
 
-      this.routeDecideButton = document.getElementById("route-decide" + me.routeNum);
+      this.routeDecideButton = document.getElementById("route-decide" + routeNum);
     }
 }
 
@@ -412,9 +412,9 @@ class AutocompleteDirectionsHandler {
     //documentに明記されていない
     directionsRenderer.addListener("routeindex_changed", function () {
       obj.elements.routeDecideButton.style.display = "block";
-      var target = directionsRenderer.getRouteIndex();
-      for (var i = 0; i < obj.poly.length; i++) {
-        if (i == target) {
+      const target = directionsRenderer.getRouteIndex();
+      for (let i = 0; i < obj.poly.length; i++) {
+        if (i === target) {
           obj.poly[i].setOptions(optionsForSelected(obj.colorCode, obj.routeNum));
         } else {
           obj.poly[i].setOptions(optionsForAlternatives(obj.routeNum));
@@ -427,11 +427,11 @@ class AutocompleteDirectionsHandler {
   setUpDecideRouteListener(obj, directionsRenderer) {
     obj.elements.routeDecideButton.addEventListener("click", function () {
         $("#add-route").attr("disabled", false);
-        var target = directionsRenderer.getRouteIndex();
+        const target = directionsRenderer.getRouteIndex();
         //ルートを決定したら、toggleを閉じる
         $("#toggle-" + obj.routeNum).next().slideToggle();
         //directionsRendererから目的のルート情報を取得してrouteObjインスタンスを作成
-        var ruoteOjb = {
+        const ruoteOjb = {
           geocoded_waypoints: directionsRenderer.directions.geocoded_waypoints,
           request: directionsRenderer.directions.request,
           routes: [directionsRenderer.directions.routes[target]],
@@ -440,8 +440,8 @@ class AutocompleteDirectionsHandler {
         };
         //選択したルートオブジェクトをmultiSearchReqに追加
         multiSearchReq["routes"][obj.routeNum] = ruoteOjb;
-        for (var i = 0; i < obj.poly.length; i++) {
-          if (i != target) {
+        for (let i = 0; i < obj.poly.length; i++) {
+          if (i !== target) {
             obj.poly[i].setMap(null);
           }
         }
@@ -450,6 +450,9 @@ class AutocompleteDirectionsHandler {
 
   //マップ上のクリックを扱うメソッド
   handleMapClick(clickedPlace) {
+    if (this.routeNum !== currRouteNum) {
+      return;
+    }
     const me = this;
     // clickした場所の情報が入ったオブジェクトでplaceIdフィールドがある場合
     if ("placeId" in clickedPlace) {
@@ -550,8 +553,8 @@ class AutocompleteDirectionsHandler {
   polyLineListenerCallback(idx, me) {
     return function () {
       me.directionsRenderer.setRouteIndex(idx);
-      for (var j = 0; j < me.poly.length; j++) {
-        if (j == idx) {
+      for (let j = 0; j < me.poly.length; j++) {
+        if (j === idx) {
           me.poly[j].setOptions(optionsForSelected(me.colorCode, me.routeNum));
         } else {
           me.poly[j].setOptions(optionsForAlternatives(me.routeNum));
@@ -591,7 +594,7 @@ class AutocompleteDirectionsHandler {
       //「すぐに出発」以外のボタンが押されている場合
       if (!me.elements.departNow.checked) {
         //ブラウザのタイムゾーンでの指定時間
-        var specTime = new Date(
+        let specTime = new Date(
           document.getElementById("date" + this.routeNum).value +
             "T" +
             document.getElementById("time" + this.routeNum).value
@@ -637,7 +640,7 @@ class AutocompleteDirectionsHandler {
       if (status === "OK") {
         //検索結果表示前に、現在の表示を全て削除
         if (me.poly.length > 0) {
-          for (var i = 0; i < me.poly.length; i++) {
+          for (let i = 0; i < me.poly.length; i++) {
             me.poly[i].setMap(null);
           }
           me.poly = [];
@@ -652,8 +655,8 @@ class AutocompleteDirectionsHandler {
           return;
         }
         //複数ルートが帰ってきた場合、それぞれについて、ラインを描画する
-        for (var i = 0; i < response.routes.length; i++) {
-          var routePolyline = new google.maps.Polyline();
+        for (let i = 0; i < response.routes.length; i++) {
+          let routePolyline = new google.maps.Polyline();
           routePolyline.setPath(response.routes[i].overview_path);
 
           //
@@ -661,7 +664,7 @@ class AutocompleteDirectionsHandler {
           routePolyline.setMap(me.map);
           me.poly.push(routePolyline);
 
-          var callback = me.polyLineListenerCallback(i, me);
+          let callback = me.polyLineListenerCallback(i, me);
           me.poly[i].addListener("click", callback);
         }
         //インデックス番号0のルートに色をつける
@@ -711,7 +714,7 @@ class AutocompleteDirectionsHandler {
 }
 
 function genSearchBox(routeId, color) {
-  var route_html_tpl = `<h2 class="toggle-title pl-3 pt-3 mb-0" id="toggle-${routeId}" style="background-color: ${color}">ルート${
+  const route_html_tpl = `<h2 class="toggle-title pl-3 pt-3 mb-0" id="toggle-${routeId}" style="background-color: ${color}">ルート${
     routeId + 1
   }</h2>
         <div class="search-fields">

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -183,6 +183,15 @@ function initMap() {
   });
 }
 
+
+class Elements {
+    constructor(routeNum) {
+        this.modeWalking = document.getElementById("changemode-walking" + routeNum);
+        this.modeTransit = document.getElementById("changemode-transit" + routeNum);
+        this.modeDriving = document.getElementById("changemode-driving" + routeNum);
+    }
+}
+
 class AutocompleteDirectionsHandler {
   constructor(map, routeNum) {
     /**
@@ -209,6 +218,7 @@ class AutocompleteDirectionsHandler {
     this.originLatitude = 0;
     this.originLongitue = 0;
     this.destinationPlaceId = "";
+    this.elements = new Elements(routeNum);
     this.timeDiffMin = 0;
     this.poly = [];
     this.inputFieldID = "";
@@ -282,18 +292,18 @@ class AutocompleteDirectionsHandler {
   setupClickListener(id, mode) {
     const radioButton = document.getElementById(id);
     radioButton.addEventListener("click", () => {
-      if (id === "changemode-transit" + this.routeNum) {
+      if (id === this.elements.modeTransit.id) {
         document.getElementById("transit-time" + this.routeNum).style.display =
           "block";
-      } else if (id !== "changemode-transit" + this.routeNum) {
+      } else if (id !== this.elements.modeTransit.id) {
         document.getElementById("transit-time" + this.routeNum).style.display =
           "none";
       }
-      if (id === "changemode-driving" + this.routeNum) {
+      if (id === this.elements.modeDriving.id) {
         document.getElementById(
           "driving-option" + this.routeNum
         ).style.display = "block";
-      } else if (id !== "changemode-driving" + this.routeNum) {
+      } else if (id !== this.elements.modeDriving.id) {
         document.getElementById(
           "driving-option" + this.routeNum
         ).style.display = "none";
@@ -313,7 +323,7 @@ class AutocompleteDirectionsHandler {
         window.alert("表示された選択肢の中から選んでください。");
         return;
       } else if (
-        document.getElementById("changemode-transit" + me.routeNum).checked &&
+        me.elements.modeTransit.checked &&
         place.formatted_address.indexOf("日本") !== -1
       ) {
         window.alert(
@@ -538,7 +548,7 @@ class AutocompleteDirectionsHandler {
       provideRouteAlternatives: true,
     };
     //公共交通機関を選択した場合
-    if (document.getElementById("changemode-transit" + this.routeNum).checked) {
+    if (this.elements.modeTransit.checked) {
       if (
         document
           .getElementById("origin-input" + me.routeNum)
@@ -591,7 +601,7 @@ class AutocompleteDirectionsHandler {
 
     //自動車ルートを指定した場合
     else if (
-      document.getElementById("changemode-driving" + this.routeNum).checked
+      this.elements.modeDriving.checked
     ) {
       //有料道路不使用の場合
       if (document.getElementById("avoid-toll" + this.routeNum).checked) {

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -103,7 +103,7 @@ window.onload = function () {
 };
 
 //地図上に路線図と道路状況を表示するlayerの表示制御
-function setUpLayersListener(id,layerController, m) {
+function setUpLayersListener(id, layerController, m) {
   return function () {
     const layerButton = document.getElementById(id);
     if (!layerButton.checked) {
@@ -111,7 +111,7 @@ function setUpLayersListener(id,layerController, m) {
     } else {
       layerController.setMap(m);
     }
-  }
+  };
 }
 
 function initMap() {
@@ -133,9 +133,21 @@ function initMap() {
   //地図上に路線図と道路状況を表示するlayer
   const transitLayer = new google.maps.TransitLayer();
   const trafficLayer = new google.maps.TrafficLayer();
-  map.controls[google.maps.ControlPosition.TOP_LEFT].push(document.getElementById("add-layers"));
-  document.getElementById("add-transport-layer").addEventListener("change", setUpLayersListener("add-transport-layer", transitLayer, map))
-  document.getElementById("add-traffic-layer").addEventListener("change", setUpLayersListener("add-traffic-layer", trafficLayer, map))
+  map.controls[google.maps.ControlPosition.TOP_LEFT].push(
+    document.getElementById("add-layers")
+  );
+  document
+    .getElementById("add-transport-layer")
+    .addEventListener(
+      "change",
+      setUpLayersListener("add-transport-layer", transitLayer, map)
+    );
+  document
+    .getElementById("add-traffic-layer")
+    .addEventListener(
+      "change",
+      setUpLayersListener("add-traffic-layer", trafficLayer, map)
+    );
 
   $("#add-route").attr("disabled", true);
   //１番目のルート要素をHTMLに追加
@@ -144,7 +156,12 @@ function initMap() {
   document.getElementById("date" + String(routeID)).min = ymd;
   document.getElementById("time" + String(routeID)).value = clock;
   //AutocompleteとDiretionsServiceのインスタンス化
-  new AutocompleteDirectionsHandler(map, String(routeID),placesService,infowindow);
+  new AutocompleteDirectionsHandler(
+    map,
+    String(routeID),
+    placesService,
+    infowindow
+  );
   $(".toggle-title").on("click", function () {
     $(this).toggleClass("active");
     $(this).next().slideToggle();
@@ -176,7 +193,12 @@ function initMap() {
     document.getElementById("date" + String(routeID)).value = ymd;
     document.getElementById("date" + String(routeID)).min = ymd;
     document.getElementById("time" + String(routeID)).value = clock;
-    new AutocompleteDirectionsHandler(map, String(routeID), placesService,infowindow);
+    new AutocompleteDirectionsHandler(
+      map,
+      String(routeID),
+      placesService,
+      infowindow
+    );
     $(".toggle-title").on("click", function () {
       $(".toggle-title").off("click");
       $(".toggle-title").on("click", function () {
@@ -188,42 +210,43 @@ function initMap() {
   });
 }
 
-
 class Elements {
-    constructor(routeNum) {
-      // 経路オプションのラジオボタン
-      this.modeWalking = document.getElementById("changemode-walking" + routeNum);
-      this.modeTransit = document.getElementById("changemode-transit" + routeNum);
-      this.modeDriving = document.getElementById("changemode-driving" + routeNum);
-      // 公共交通機関のオプション指定
-      this.transitOption = document.getElementById("transit-time" + routeNum);
-      this.departNow = document.getElementById("depart-now" + routeNum);
-      this.specifyDeparture = document.getElementById("depart-time" + routeNum);
-      this.specifyArrival = document.getElementById("arrival-time" + routeNum);
+  constructor(routeNum) {
+    // 経路オプションのラジオボタン
+    this.modeWalking = document.getElementById("changemode-walking" + routeNum);
+    this.modeTransit = document.getElementById("changemode-transit" + routeNum);
+    this.modeDriving = document.getElementById("changemode-driving" + routeNum);
+    // 公共交通機関のオプション指定
+    this.transitOption = document.getElementById("transit-time" + routeNum);
+    this.departNow = document.getElementById("depart-now" + routeNum);
+    this.specifyDeparture = document.getElementById("depart-time" + routeNum);
+    this.specifyArrival = document.getElementById("arrival-time" + routeNum);
 
-      //自動車のオプション指定
-      this.drivingOption = document.getElementById("driving-option" + routeNum);
-      this.avoidToll = document.getElementById("avoid-toll" + routeNum);
-      this.avoidHighway = document.getElementById("avoid-highway" + routeNum);
+    //自動車のオプション指定
+    this.drivingOption = document.getElementById("driving-option" + routeNum);
+    this.avoidToll = document.getElementById("avoid-toll" + routeNum);
+    this.avoidHighway = document.getElementById("avoid-highway" + routeNum);
 
-      //出発地の入力
-      this.originInput = document.getElementById("origin-input" + routeNum);
-      //目的地の入力
-      this.destinationInput = document.getElementById("destination-input" + routeNum);
+    //出発地の入力
+    this.originInput = document.getElementById("origin-input" + routeNum);
+    //目的地の入力
+    this.destinationInput = document.getElementById(
+      "destination-input" + routeNum
+    );
 
-      this.routeDecideButton = document.getElementById("route-decide" + routeNum);
-    }
+    this.routeDecideButton = document.getElementById("route-decide" + routeNum);
+  }
 }
 
-
-const MSG_CANNOT_USE_IN_JAPAN = "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。" +
-                                "海外の公共交通機関情報はご利用いただけます。"
+const MSG_CANNOT_USE_IN_JAPAN =
+  "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。" +
+  "海外の公共交通機関情報はご利用いただけます。";
 const AUTO_COMPLETE_FIELDS = [
-    "place_id",
-    "geometry",
-    "formatted_address",
-    "utc_offset_minutes",
-    ]
+  "place_id",
+  "geometry",
+  "formatted_address",
+  "utc_offset_minutes",
+];
 
 const defaultPolyLineOptions = {
   clickable: true,
@@ -232,11 +255,11 @@ const defaultPolyLineOptions = {
   strokeColor: "#808080",
   strokeOpacity: 0.7,
   strokeWeight: 7,
-}
+};
 
 function optionsForAlternatives(zIndex) {
   let polyLineOptions = Object.assign({}, defaultPolyLineOptions);
-  polyLineOptions.zIndex =  parseInt(zIndex);
+  polyLineOptions.zIndex = parseInt(zIndex);
   return polyLineOptions;
 }
 
@@ -249,8 +272,6 @@ function optionsForSelected(strokeColor, zIndex) {
   selectedPolyLine.zIndex = parseInt(zIndex) + 1;
   return selectedPolyLine;
 }
-
-
 
 class AutocompleteDirectionsHandler {
   constructor(map, routeNum, placesService, infowindow) {
@@ -292,7 +313,9 @@ class AutocompleteDirectionsHandler {
       document.getElementById("route-detail-panel" + this.routeNum)
     );
 
-    const originAutocomplete = new google.maps.places.Autocomplete(this.elements.originInput);
+    const originAutocomplete = new google.maps.places.Autocomplete(
+      this.elements.originInput
+    );
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
     originAutocomplete.setFields(AUTO_COMPLETE_FIELDS);
     const destinationAutocomplete = new google.maps.places.Autocomplete(
@@ -338,11 +361,9 @@ class AutocompleteDirectionsHandler {
     const radioButton = document.getElementById(id);
     radioButton.addEventListener("click", () => {
       if (id === this.elements.modeTransit.id) {
-        this.elements.transitOption.style.display =
-          "block";
+        this.elements.transitOption.style.display = "block";
       } else {
-        this.elements.transitOption.style.display =
-          "none";
+        this.elements.transitOption.style.display = "none";
       }
       if (id === this.elements.modeDriving.id) {
         this.elements.drivingOption.style.display = "block";
@@ -415,7 +436,9 @@ class AutocompleteDirectionsHandler {
       const target = directionsRenderer.getRouteIndex();
       for (let i = 0; i < obj.poly.length; i++) {
         if (i === target) {
-          obj.poly[i].setOptions(optionsForSelected(obj.colorCode, obj.routeNum));
+          obj.poly[i].setOptions(
+            optionsForSelected(obj.colorCode, obj.routeNum)
+          );
         } else {
           obj.poly[i].setOptions(optionsForAlternatives(obj.routeNum));
         }
@@ -426,26 +449,28 @@ class AutocompleteDirectionsHandler {
 
   setUpDecideRouteListener(obj, directionsRenderer) {
     obj.elements.routeDecideButton.addEventListener("click", function () {
-        $("#add-route").attr("disabled", false);
-        const target = directionsRenderer.getRouteIndex();
-        //ルートを決定したら、toggleを閉じる
-        $("#toggle-" + obj.routeNum).next().slideToggle();
-        //directionsRendererから目的のルート情報を取得してrouteObjインスタンスを作成
-        const ruoteOjb = {
-          geocoded_waypoints: directionsRenderer.directions.geocoded_waypoints,
-          request: directionsRenderer.directions.request,
-          routes: [directionsRenderer.directions.routes[target]],
-          status: directionsRenderer.directions.status,
-          __proto__: directionsRenderer.directions.__proto__,
-        };
-        //選択したルートオブジェクトをmultiSearchReqに追加
-        multiSearchReq["routes"][obj.routeNum] = ruoteOjb;
-        for (let i = 0; i < obj.poly.length; i++) {
-          if (i !== target) {
-            obj.poly[i].setMap(null);
-          }
+      $("#add-route").attr("disabled", false);
+      const target = directionsRenderer.getRouteIndex();
+      //ルートを決定したら、toggleを閉じる
+      $("#toggle-" + obj.routeNum)
+        .next()
+        .slideToggle();
+      //directionsRendererから目的のルート情報を取得してrouteObjインスタンスを作成
+      const ruoteOjb = {
+        geocoded_waypoints: directionsRenderer.directions.geocoded_waypoints,
+        request: directionsRenderer.directions.request,
+        routes: [directionsRenderer.directions.routes[target]],
+        status: directionsRenderer.directions.status,
+        __proto__: directionsRenderer.directions.__proto__,
+      };
+      //選択したルートオブジェクトをmultiSearchReqに追加
+      multiSearchReq["routes"][obj.routeNum] = ruoteOjb;
+      for (let i = 0; i < obj.poly.length; i++) {
+        if (i !== target) {
+          obj.poly[i].setMap(null);
         }
-      });
+      }
+    });
   }
 
   //マップ上のクリックを扱うメソッド
@@ -483,12 +508,12 @@ class AutocompleteDirectionsHandler {
           place.geometry &&
           place.geometry.location
         ) {
-            me.infowindow.open(me.map);
-            me.infowindow.setPosition(place.geometry.location);
-            me.infowindowContent.children["place-icon"].src = place.icon;
-            me.infowindowContent.children["place-name"].textContent = place.name;
-            me.infowindowContent.children["place-address"].textContent =
-                place.formatted_address;
+          me.infowindow.open(me.map);
+          me.infowindow.setPosition(place.geometry.location);
+          me.infowindowContent.children["place-icon"].src = place.icon;
+          me.infowindowContent.children["place-name"].textContent = place.name;
+          me.infowindowContent.children["place-address"].textContent =
+            place.formatted_address;
         }
       }
     );
@@ -496,47 +521,50 @@ class AutocompleteDirectionsHandler {
 
   getPlaceInfoForClick(placeId, me) {
     me.placesService.getDetails(
-        {
-          placeId: placeId,
-          fields: [
-            "icon",
-            "name",
-            "place_id",
-            "formatted_address",
-            "geometry",
-            "utc_offset_minutes",
-          ],
-        },
-        (place, status) => {
-          if (
-              status === "OK" &&
-              place &&
-              place.geometry &&
-              place.geometry.location
-          ) {
-            //入力が選択されていなければ、出発地として扱う
-            if (!me.focusedElementID) {
-              me.focusedElementID = "origin-input" + me.routeNum;
-            }
-            document.getElementById(me.focusedElementID).value =
-                place.formatted_address;
-            if (me.focusedElementID === "origin-input" + me.routeNum) {
-              me.originPlaceId = place.place_id;
-              //UTCとの時差をminutes単位で取得
-              me.timeDiffMin = place.utc_offset_minutes;
-            } else if (me.focusedElementID === "destination-input" + me.routeNum) {
-              me.destinationPlaceId = place.place_id;
-            }
-            me.infowindow.open(me.map);
-            me.infowindow.setPosition(place.geometry.location);
-            me.infowindowContent.children["place-icon"].src = place.icon;
-            me.infowindowContent.children["place-name"].textContent = place.name;
-            me.infowindowContent.children["place-address"].textContent =
-                place.formatted_address;
-
-            me.route();
+      {
+        placeId: placeId,
+        fields: [
+          "icon",
+          "name",
+          "place_id",
+          "formatted_address",
+          "geometry",
+          "utc_offset_minutes",
+        ],
+      },
+      (place, status) => {
+        if (
+          status === "OK" &&
+          place &&
+          place.geometry &&
+          place.geometry.location
+        ) {
+          //入力が選択されていなければ、出発地として扱う
+          if (!me.focusedElementID) {
+            me.focusedElementID = "origin-input" + me.routeNum;
           }
+          document.getElementById(me.focusedElementID).value =
+            place.formatted_address;
+          if (me.focusedElementID === "origin-input" + me.routeNum) {
+            me.originPlaceId = place.place_id;
+            //UTCとの時差をminutes単位で取得
+            me.timeDiffMin = place.utc_offset_minutes;
+          } else if (
+            me.focusedElementID ===
+            "destination-input" + me.routeNum
+          ) {
+            me.destinationPlaceId = place.place_id;
+          }
+          me.infowindow.open(me.map);
+          me.infowindow.setPosition(place.geometry.location);
+          me.infowindowContent.children["place-icon"].src = place.icon;
+          me.infowindowContent.children["place-name"].textContent = place.name;
+          me.infowindowContent.children["place-address"].textContent =
+            place.formatted_address;
+
+          me.route();
         }
+      }
     );
   }
 
@@ -579,9 +607,7 @@ class AutocompleteDirectionsHandler {
     };
     //公共交通機関を選択した場合
     if (this.elements.modeTransit.checked) {
-      if (
-          me.elements.originInput.value.indexOf("日本") !== -1
-      ) {
+      if (me.elements.originInput.value.indexOf("日本") !== -1) {
         window.alert(MSG_CANNOT_USE_IN_JAPAN);
         return;
       }
@@ -649,8 +675,7 @@ class AutocompleteDirectionsHandler {
           response.request.travelMode === "TRANSIT" &&
           response.routes[0].legs[0].start_address.match(/日本/)
         ) {
-          me.elements.routeDecideButton.style.display =
-            "none";
+          me.elements.routeDecideButton.style.display = "none";
           alert(MSG_CANNOT_USE_IN_JAPAN);
           return;
         }
@@ -703,8 +728,7 @@ class AutocompleteDirectionsHandler {
         }
         //STATUS != OKの場合
       } else {
-        me.elements.routeDecideButton.style.display =
-          "none";
+        me.elements.routeDecideButton.style.display = "none";
         window.alert(
           "ルートが見つかりませんでした。出発地と目的地の距離が遠すぎる場合、結果が表示されない場合があります。"
         );

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -191,8 +191,13 @@ class Elements {
         this.modeDriving = document.getElementById("changemode-driving" + routeNum);
 
 
-      this.transitOption = document.getElementById("transit-time" + routeNum)
-      this.drivingOption = document.getElementById("driving-option" + routeNum)
+      this.transitOption = document.getElementById("transit-time" + routeNum);
+      this.drivingOption = document.getElementById("driving-option" + routeNum);
+
+      //出発地の入力
+      this.originInput = document.getElementById("origin-input" + routeNum);
+      //目的地の入力
+      this.destinationInput = document.getElementById("destination-input" + routeNum);
     }
 }
 
@@ -234,13 +239,8 @@ class AutocompleteDirectionsHandler {
     this.directionsRenderer.setPanel(
       document.getElementById("route-detail-panel" + this.routeNum)
     );
-    //出発地の入力値
-    const originInput = document.getElementById("origin-input" + this.routeNum);
-    //目的地の入力値
-    const destinationInput = document.getElementById(
-      "destination-input" + this.routeNum
-    );
-    const originAutocomplete = new google.maps.places.Autocomplete(originInput);
+
+    const originAutocomplete = new google.maps.places.Autocomplete(this.elements.originInput);
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
     originAutocomplete.setFields([
       "place_id",
@@ -249,7 +249,7 @@ class AutocompleteDirectionsHandler {
       "utc_offset_minutes",
     ]);
     const destinationAutocomplete = new google.maps.places.Autocomplete(
-      destinationInput
+      this.elements.destinationInput
     );
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
     destinationAutocomplete.setFields([

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -422,7 +422,7 @@ class AutocompleteDirectionsHandler {
   setupTimeListener(id, rNum) {
     const timeNow = document.getElementById(id);
     timeNow.addEventListener("click", () => {
-      document.getElementById("date" + rNum).value = yyyy + "-" + mm + "-" + dd;
+      document.getElementById("date" + rNum).value = ymd;
       document.getElementById("time" + rNum).value = clock;
       this.route();
     });

--- a/app/templates/multi_search/search/multi_search.js
+++ b/app/templates/multi_search/search/multi_search.js
@@ -272,7 +272,7 @@ class AutocompleteDirectionsHandler {
     this.elements = new Elements(routeNum);
     this.timeDiffMin = 0;
     this.poly = [];
-    this.inputFieldID = "";
+    this.focusedElementID = "";
     this.travelMode = google.maps.TravelMode.WALKING;
     this.directionsService = new google.maps.DirectionsService();
     this.directionsRenderer = new google.maps.DirectionsRenderer();
@@ -507,16 +507,16 @@ class AutocompleteDirectionsHandler {
               place.geometry.location
           ) {
             //入力が選択されていなければ、出発地として扱う
-            if (!me.inputFieldID) {
-              me.inputFieldID = "origin-input" + me.routeNum;
+            if (!me.focusedElementID) {
+              me.focusedElementID = "origin-input" + me.routeNum;
             }
-            document.getElementById(me.inputFieldID).value =
+            document.getElementById(me.focusedElementID).value =
                 place.formatted_address;
-            if (me.inputFieldID === "origin-input" + me.routeNum) {
+            if (me.focusedElementID === "origin-input" + me.routeNum) {
               me.originPlaceId = place.place_id;
               //UTCとの時差をminutes単位で取得
               me.timeDiffMin = place.utc_offset_minutes;
-            } else if (me.inputFieldID === "destination-input" + me.routeNum) {
+            } else if (me.focusedElementID === "destination-input" + me.routeNum) {
               me.destinationPlaceId = place.place_id;
             }
             me.infowindow.open(me.map);
@@ -537,7 +537,7 @@ class AutocompleteDirectionsHandler {
     const currentInput = document.getElementById(id);
     currentInput.addEventListener("focus", () => {
       currRouteNum = me.routeNum; //focusされたら、currRouteNumを選択されたルート番号に設定
-      me.inputFieldID = id;
+      me.focusedElementID = id;
     });
   }
 

--- a/app/templates/multi_search/show_and_edit/multi_route_show.js
+++ b/app/templates/multi_search/show_and_edit/multi_route_show.js
@@ -1,5 +1,5 @@
 //ルート番号
-var routeID = Object.keys(routeInfo.routes).length - 1;
+let routeID = Object.keys(routeInfo.routes).length - 1;
 //ルート描画時の線の色を指定
 const colorMap = {
   0: "#00bfff",
@@ -19,7 +19,7 @@ delete multiSearchUpdateReq.route_count;
 multiSearchUpdateReq["previous_title"] = routeInfo.title;
 
 // 入力中のルート番号を入れる
-var currRouteNum = "0";
+let currRouteNum = "0";
 
 //Ajax通信
 $(function () {
@@ -35,7 +35,7 @@ $(function () {
     }
     multiSearchUpdateReq["title"] = document.getElementById("route-name").value;
     // 多重送信を防ぐため通信完了までボタンをdisableにする
-    var button = $(this);
+    const button = $(this);
     button.attr("disabled", true);
 
     $.ajax({
@@ -72,17 +72,17 @@ $(function () {
 });
 
 //現在時刻を取得し、時間指定要素に挿入
-var today = new Date();
-var yyyy = today.getFullYear();
-var mm = ("0" + (today.getMonth() + 1)).slice(-2); //getMonthは0 ~ 11
-var dd = ("0" + today.getDate()).slice(-2);
-var ymd = yyyy + "-" + mm + "-" + dd;
-var hr = ("0" + today.getHours()).slice(-2);
-var minu = ("0" + today.getMinutes()).slice(-2);
-var clock = hr + ":" + minu + ":00";
+let today = new Date();
+let yyyy = today.getFullYear();
+let mm = ("0" + (today.getMonth() + 1)).slice(-2); //getMonthは0 ~ 11
+let dd = ("0" + today.getDate()).slice(-2);
+let ymd = yyyy + "-" + mm + "-" + dd;
+let hr = ("0" + today.getHours()).slice(-2);
+let minu = ("0" + today.getMinutes()).slice(-2);
+let clock = hr + ":" + minu + ":00";
 
 //ブラウザのタイムゾーンのUTCからの時差をminutes単位で取得
-var tzoneOffsetminu = today.getTimezoneOffset();
+let tzoneOffsetminu = today.getTimezoneOffset();
 
 //Google Maps API実行ファイル読み込み
 window.onload = function () {
@@ -100,15 +100,15 @@ window.onload = function () {
 };
 
 //地図上に路線図と道路状況を表示するlayerの表示制御
-function setUpLayersListener(id,layerController, m) {
+function setUpLayersListener(id, layerController, m) {
   return function () {
-    var layerButton = document.getElementById(id);
+    const layerButton = document.getElementById(id);
     if (!layerButton.checked) {
       layerController.setMap(null);
     } else {
       layerController.setMap(m);
     }
-  }
+  };
 }
 
 function initMap() {
@@ -122,19 +122,35 @@ function initMap() {
       gestureHandling: "greedy", //地図埋め込み時Ctrボタン要求の無効化
     },
   });
+  const placesService = new google.maps.places.PlacesService(map);
+  const infowindow = new google.maps.InfoWindow();
+  const infowindowContent = document.getElementById("infowindow-content");
+  infowindow.setContent(infowindowContent);
 
   //地図上に路線図と道路状況を表示するlayer
   const transitLayer = new google.maps.TransitLayer();
   const trafficLayer = new google.maps.TrafficLayer();
-  map.controls[google.maps.ControlPosition.TOP_LEFT].push(document.getElementById("add-layers"));
-  document.getElementById("add-transport-layer").addEventListener("change", setUpLayersListener("add-transport-layer", transitLayer, map))
-  document.getElementById("add-traffic-layer").addEventListener("change", setUpLayersListener("add-traffic-layer", trafficLayer, map))
+  map.controls[google.maps.ControlPosition.TOP_LEFT].push(
+    document.getElementById("add-layers")
+  );
+  document
+    .getElementById("add-transport-layer")
+    .addEventListener(
+      "change",
+      setUpLayersListener("add-transport-layer", transitLayer, map)
+    );
+  document
+    .getElementById("add-traffic-layer")
+    .addEventListener(
+      "change",
+      setUpLayersListener("add-traffic-layer", trafficLayer, map)
+    );
 
   //ルート名をDBから読み込んだルート名に設定
   document.getElementById("route-name").value = routeInfo.title;
   multiSearchUpdateReq.title = routeInfo.title;
   //保存されているルート要素をHTMLに追加
-  for (var i = 0; i < Object.keys(routeInfo.routes).length; i++) {
+  for (let i = 0; i < Object.keys(routeInfo.routes).length; i++) {
     multiSearchUpdateReq.routes[String(i)] = routeInfo.routes[i];
     $("#search-box").append(genSearchBox(i, colorMap[i]));
     document.getElementById("origin-input" + String(i)).value =
@@ -145,10 +161,17 @@ function initMap() {
     document.getElementById("date" + String(i)).min = ymd;
     document.getElementById("time" + String(i)).value = clock;
     //AutocompleteとDiretionsServiceのインスタンス化
-    var originID = routeInfo.routes[i].request.origin["placeId"];
-    var destID = routeInfo.routes[i].request.destination["placeId"];
+    let originID = routeInfo.routes[i].request.origin["placeId"];
+    let destID = routeInfo.routes[i].request.destination["placeId"];
 
-    new AutocompleteDirectionsHandler(map, String(i), originID, destID);
+    new AutocompleteDirectionsHandler(
+      map,
+      String(i),
+      originID,
+      destID,
+      placesService,
+      infowindow
+    );
     //読み込んだルートのtoggleは閉じた状態で表示する
     $(".toggle-title").on("click", function () {
       $(".toggle-title").off("click");
@@ -190,7 +213,14 @@ function initMap() {
     document.getElementById("date" + String(routeID)).value = ymd;
     document.getElementById("date" + String(routeID)).min = ymd;
     document.getElementById("time" + String(i)).value = clock;
-    new AutocompleteDirectionsHandler(map, String(routeID), "", "");
+    new AutocompleteDirectionsHandler(
+      map,
+      String(routeID),
+      "",
+      "",
+      placesService,
+      infowindow
+    );
     $(".toggle-title").on("click", function () {
       $(".toggle-title").off("click");
       $(".toggle-title").on("click", function () {
@@ -202,8 +232,71 @@ function initMap() {
   });
 }
 
+class Elements {
+  constructor(routeNum) {
+    // 経路オプションのラジオボタン
+    this.modeWalking = document.getElementById("changemode-walking" + routeNum);
+    this.modeTransit = document.getElementById("changemode-transit" + routeNum);
+    this.modeDriving = document.getElementById("changemode-driving" + routeNum);
+    // 公共交通機関のオプション指定
+    this.transitOption = document.getElementById("transit-time" + routeNum);
+    this.departNow = document.getElementById("depart-now" + routeNum);
+    this.specifyDeparture = document.getElementById("depart-time" + routeNum);
+    this.specifyArrival = document.getElementById("arrival-time" + routeNum);
+
+    //自動車のオプション指定
+    this.drivingOption = document.getElementById("driving-option" + routeNum);
+    this.avoidToll = document.getElementById("avoid-toll" + routeNum);
+    this.avoidHighway = document.getElementById("avoid-highway" + routeNum);
+
+    //出発地の入力
+    this.originInput = document.getElementById("origin-input" + routeNum);
+    //目的地の入力
+    this.destinationInput = document.getElementById(
+      "destination-input" + routeNum
+    );
+
+    this.routeDecideButton = document.getElementById("route-decide" + routeNum);
+  }
+}
+
+const MSG_CANNOT_USE_IN_JAPAN =
+  "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。" +
+  "海外の公共交通機関情報はご利用いただけます。";
+const AUTO_COMPLETE_FIELDS = [
+  "place_id",
+  "geometry",
+  "formatted_address",
+  "utc_offset_minutes",
+];
+
+const defaultPolyLineOptions = {
+  clickable: true,
+  //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
+  //元に戻すためには、全てのルートについて#808080に設定する必要あり。)
+  strokeColor: "#808080",
+  strokeOpacity: 0.7,
+  strokeWeight: 7,
+};
+
+function optionsForAlternatives(zIndex) {
+  let polyLineOptions = Object.assign({}, defaultPolyLineOptions);
+  polyLineOptions.zIndex = parseInt(zIndex);
+  return polyLineOptions;
+}
+
+function optionsForSelected(strokeColor, zIndex) {
+  let selectedPolyLine = Object.assign({}, defaultPolyLineOptions);
+  //選択したルートの色をcolorCodeに従って変更
+  selectedPolyLine.strokeColor = strokeColor;
+  selectedPolyLine.strokeOpacity = 1.0;
+  //色付きラインを一番上に表示するため、zIndexを大きくする
+  selectedPolyLine.zIndex = parseInt(zIndex) + 1;
+  return selectedPolyLine;
+}
+
 class AutocompleteDirectionsHandler {
-  constructor(map, routeNum, originID, destID) {
+  constructor(map, routeNum, originID, destID, placesService, infowindow) {
     /**
      * Assign the project to an employee.
      * @param {String} routeNum - ルートのIndex番号
@@ -214,6 +307,7 @@ class AutocompleteDirectionsHandler {
      * @param {Number} originLatitude - Autocomplete Serviceで地名から取得された緯度
      * @param {Number} originLongitude - Autocomplete Serviceで地名から取得された経度
      * @param {String} destinationPlaceId - Autocomplete Serviceで地名から変換された地点ID
+     * @param {Object} elements - classに関連するDOM要素
      * @param {Number} timeDiffMin - TimeZone APIから取得された出発地のoffset
      * @param {Array} poly - ルートごとのdirectionRendererオブジェクトの配列
      * @param {Object} travelMode - directionsRequestのオプションフィールド
@@ -228,9 +322,10 @@ class AutocompleteDirectionsHandler {
     this.originLatitude = 0;
     this.originLongitue = 0;
     this.destinationPlaceId = destID;
+    this.elements = new Elements(routeNum);
     this.timeDiffMin = 0;
     this.poly = [];
-    this.inputFieldID = "";
+    this.focusedElementID = "";
     this.travelMode = google.maps.TravelMode.WALKING;
     this.directionsService = new google.maps.DirectionsService();
     this.directionsRenderer = new google.maps.DirectionsRenderer();
@@ -242,14 +337,10 @@ class AutocompleteDirectionsHandler {
     );
     //保存されているルートのみ色付きラインを描画
     if (parseInt(routeNum) < Object.keys(routeInfo.routes).length) {
-      this.directionsRenderer.setOptions({
-        //Colorとopacity(不透明度)と太さを設定
-        polylineOptions: {
-          strokeColor: this.colorCode,
-          strokeOpacity: 1.0,
-          strokeWeight: 7,
-        },
-      });
+      console.log(this.colorCode);
+      this.directionsRenderer.setOptions(
+        optionsForSelected(this.colorCode, this.routeNum)
+      );
       this.directionsRenderer.setDirections(routeInfo.routes[routeNum]);
       document.getElementById("one-result-panel" + routeNum).style.display =
         "block";
@@ -261,30 +352,17 @@ class AutocompleteDirectionsHandler {
         " ," +
         routeInfo.routes[routeNum].routes[0].legs[0].duration.text;
     }
-    //出発地の入力値
-    const originInput = document.getElementById("origin-input" + this.routeNum);
-    //目的地の入力値
-    const destinationInput = document.getElementById(
-      "destination-input" + this.routeNum
+
+    const originAutocomplete = new google.maps.places.Autocomplete(
+      this.elements.originInput
     );
-    const originAutocomplete = new google.maps.places.Autocomplete(originInput);
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
-    originAutocomplete.setFields([
-      "place_id",
-      "geometry",
-      "formatted_address",
-      "utc_offset_minutes",
-    ]);
+    originAutocomplete.setFields(AUTO_COMPLETE_FIELDS);
     const destinationAutocomplete = new google.maps.places.Autocomplete(
-      destinationInput
+      this.elements.destinationInput
     );
     //Places detailは高額料金がかかるので、必要なフィールドを指定して、料金を下げる
-    destinationAutocomplete.setFields([
-      "place_id",
-      "geometry",
-      "formatted_address",
-      "utc_offset_minutes",
-    ]);
+    destinationAutocomplete.setFields(AUTO_COMPLETE_FIELDS);
 
     //EventListenerの設定
     this.setupClickListener(
@@ -309,10 +387,9 @@ class AutocompleteDirectionsHandler {
     this.setUpRouteSelectedListener(this, this.directionsRenderer);
     this.setUpDecideRouteListener(this, this.directionsRenderer);
     //マップ上のクリックに対する処理の設定
-    this.placesService = new google.maps.places.PlacesService(map);
-    this.infowindow = new google.maps.InfoWindow();
+    this.placesService = placesService;
+    this.infowindow = infowindow;
     this.infowindowContent = document.getElementById("infowindow-content");
-    this.infowindow.setContent(this.infowindowContent);
     this.map.addListener("click", this.handleMapClick.bind(this));
     this.getFocusedElementID("origin-input" + this.routeNum, this);
     this.getFocusedElementID("destination-input" + this.routeNum, this);
@@ -322,21 +399,15 @@ class AutocompleteDirectionsHandler {
   setupClickListener(id, mode) {
     const radioButton = document.getElementById(id);
     radioButton.addEventListener("click", () => {
-      if (id === "changemode-transit" + this.routeNum) {
-        document.getElementById("transit-time" + this.routeNum).style.display =
-          "block";
-      } else if (id !== "changemode-transit" + this.routeNum) {
-        document.getElementById("transit-time" + this.routeNum).style.display =
-          "none";
+      if (id === this.elements.modeTransit.id) {
+        this.elements.transitOption.style.display = "block";
+      } else {
+        this.elements.transitOption.style.display = "none";
       }
-      if (id === "changemode-driving" + this.routeNum) {
-        document.getElementById(
-          "driving-option" + this.routeNum
-        ).style.display = "block";
-      } else if (id !== "changemode-driving" + this.routeNum) {
-        document.getElementById(
-          "driving-option" + this.routeNum
-        ).style.display = "none";
+      if (id === this.elements.modeDriving.id) {
+        this.elements.drivingOption.style.display = "block";
+      } else if (id !== this.elements.modeDriving.id) {
+        this.elements.drivingOption.style.display = "none";
       }
       this.travelMode = mode;
       this.route();
@@ -347,18 +418,16 @@ class AutocompleteDirectionsHandler {
   setupPlaceChangedListener(autocomplete, mode, me) {
     autocomplete.bindTo("bounds", this.map);
     autocomplete.addListener("place_changed", () => {
-      me.infowindow.close(); //クリックした場所の詳細表示を削除
+      // me.infowindow.close(); //クリックした場所の詳細表示を削除
       const place = autocomplete.getPlace();
       if (!place.place_id) {
         window.alert("表示された選択肢の中から選んでください。");
         return;
       } else if (
-        document.getElementById("changemode-transit" + me.routeNum).checked &&
+        me.elements.modeTransit.checked &&
         place.formatted_address.indexOf("日本") !== -1
       ) {
-        window.alert(
-          "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-        );
+        window.alert(MSG_CANNOT_USE_IN_JAPAN);
         return;
       }
       if (mode === "ORIG") {
@@ -375,7 +444,8 @@ class AutocompleteDirectionsHandler {
       //経度と緯度を設定
       me.originLatitude = place.geometry.location.lat();
       me.originLongitue = place.geometry.location.lng();
-      me.getPlaceInformation(place.place_id, me);
+      me.getPlaceInfo(place.place_id, me);
+      me.route();
     });
   }
 
@@ -401,31 +471,15 @@ class AutocompleteDirectionsHandler {
   setUpRouteSelectedListener(obj, directionsRenderer) {
     //documentに明記されていない
     directionsRenderer.addListener("routeindex_changed", function () {
-      document.getElementById("route-decide" + obj.routeNum).style.display =
-        "block";
-      var target = directionsRenderer.getRouteIndex();
-      for (var i = 0; i < obj.poly.length; i++) {
-        if (i == target) {
-          obj.poly[i].setOptions({
-            //選択したルートの場合、色をcolorCodeに従って変更
-            clickable: true,
-            strokeColor: obj.colorCode,
-            strokeOpacity: 1.0,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを他のルートより大きくする。
-            zIndex: parseInt(obj.routeNum) + 1,
-          });
+      obj.elements.routeDecideButton.style.display = "block";
+      const target = directionsRenderer.getRouteIndex();
+      for (let i = 0; i < obj.poly.length; i++) {
+        if (i === target) {
+          obj.poly[i].setOptions(
+            optionsForSelected(obj.colorCode, obj.routeNum)
+          );
         } else {
-          obj.poly[i].setOptions({
-            //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
-            //元に戻すためには、全てのルートについて#808080に設定する必要あり。)
-            clickable: true,
-            strokeColor: "#808080",
-            strokeOpacity: 0.7,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを小さくする
-            zIndex: parseInt(obj.routeNum),
-          });
+          obj.poly[i].setOptions(optionsForAlternatives(obj.routeNum));
         }
         obj.poly[i].setMap(obj.map);
       }
@@ -433,31 +487,29 @@ class AutocompleteDirectionsHandler {
   }
 
   setUpDecideRouteListener(obj, directionsRenderer) {
-    document
-      .getElementById("route-decide" + obj.routeNum)
-      .addEventListener("click", function () {
-        $("#add-route").attr("disabled", false);
-        var target = directionsRenderer.getRouteIndex();
-        //ルートを決定したら、toggleを閉じる
-        $("#toggle-" + obj.routeNum)
-          .next()
-          .slideToggle();
-        //directionsRendererから目的のルート情報を取得してrouteObjインスタンスを作成
-        var ruoteOjb = {
-          geocoded_waypoints: directionsRenderer.directions.geocoded_waypoints,
-          request: directionsRenderer.directions.request,
-          routes: [directionsRenderer.directions.routes[target]],
-          status: directionsRenderer.directions.status,
-          __proto__: directionsRenderer.directions.__proto__,
-        };
-        //選択したルートオブジェクトをmultiSearchUpdateReqに追加
-        multiSearchUpdateReq["routes"][obj.routeNum] = ruoteOjb;
-        for (var i = 0; i < obj.poly.length; i++) {
-          if (i != target) {
-            obj.poly[i].setMap(null);
-          }
+    obj.elements.routeDecideButton.addEventListener("click", function () {
+      $("#add-route").attr("disabled", false);
+      const target = directionsRenderer.getRouteIndex();
+      //ルートを決定したら、toggleを閉じる
+      $("#toggle-" + obj.routeNum)
+        .next()
+        .slideToggle();
+      //directionsRendererから目的のルート情報を取得してrouteObjインスタンスを作成
+      const ruoteOjb = {
+        geocoded_waypoints: directionsRenderer.directions.geocoded_waypoints,
+        request: directionsRenderer.directions.request,
+        routes: [directionsRenderer.directions.routes[target]],
+        status: directionsRenderer.directions.status,
+        __proto__: directionsRenderer.directions.__proto__,
+      };
+      //選択したルートオブジェクトをmultiSearchUpdateReqに追加
+      multiSearchUpdateReq["routes"][obj.routeNum] = ruoteOjb;
+      for (let i = 0; i < obj.poly.length; i++) {
+        if (i !== target) {
+          obj.poly[i].setMap(null);
         }
-      });
+      }
+    });
   }
 
   //マップ上のクリックを扱うメソッド
@@ -466,17 +518,47 @@ class AutocompleteDirectionsHandler {
       return;
     }
     const me = this;
+    // clickした場所の情報が入ったオブジェクトでplaceIdフィールドがある場合
     if ("placeId" in clickedPlace) {
-      // デフォルトのinfo windowを無効化
-      clickedPlace.stop();
       if (clickedPlace.placeId) {
-        this.getPlaceInformation(clickedPlace.placeId, me);
+        this.getPlaceInfoForClick(clickedPlace.placeId, me);
       }
     }
   }
 
   //クリックした場所の情報表示とルート検索を行うメソッド
-  getPlaceInformation(placeId, me) {
+  getPlaceInfo(placeId, me) {
+    me.placesService.getDetails(
+      {
+        placeId: placeId,
+        fields: [
+          "icon",
+          "name",
+          "place_id",
+          "formatted_address",
+          "geometry",
+          "utc_offset_minutes",
+        ],
+      },
+      (place, status) => {
+        if (
+          status === "OK" &&
+          place &&
+          place.geometry &&
+          place.geometry.location
+        ) {
+          me.infowindow.open(me.map);
+          me.infowindow.setPosition(place.geometry.location);
+          me.infowindowContent.children["place-icon"].src = place.icon;
+          me.infowindowContent.children["place-name"].textContent = place.name;
+          me.infowindowContent.children["place-address"].textContent =
+            place.formatted_address;
+        }
+      }
+    );
+  }
+
+  getPlaceInfoForClick(placeId, me) {
     me.placesService.getDetails(
       {
         placeId: placeId,
@@ -497,25 +579,27 @@ class AutocompleteDirectionsHandler {
           place.geometry.location
         ) {
           //入力が選択されていなければ、出発地として扱う
-          if (!me.inputFieldID) {
-            me.inputFieldID = "origin-input" + me.routeNum;
+          if (!me.focusedElementID) {
+            me.focusedElementID = "origin-input" + me.routeNum;
           }
-          document.getElementById(me.inputFieldID).value =
+          document.getElementById(me.focusedElementID).value =
             place.formatted_address;
-          if (me.inputFieldID === "origin-input" + me.routeNum) {
+          if (me.focusedElementID === "origin-input" + me.routeNum) {
             me.originPlaceId = place.place_id;
             //UTCとの時差をminutes単位で取得
             me.timeDiffMin = place.utc_offset_minutes;
-          } else if (me.inputFieldID === "destination-input" + me.routeNum) {
+          } else if (
+            me.focusedElementID ===
+            "destination-input" + me.routeNum
+          ) {
             me.destinationPlaceId = place.place_id;
           }
-          me.infowindow.close();
+          me.infowindow.open(me.map);
           me.infowindow.setPosition(place.geometry.location);
           me.infowindowContent.children["place-icon"].src = place.icon;
           me.infowindowContent.children["place-name"].textContent = place.name;
           me.infowindowContent.children["place-address"].textContent =
             place.formatted_address;
-          me.infowindow.open(me.map);
 
           me.route();
         }
@@ -528,7 +612,7 @@ class AutocompleteDirectionsHandler {
     const currentInput = document.getElementById(id);
     currentInput.addEventListener("focus", () => {
       currRouteNum = me.routeNum; //focusされたら、currRouteNumを選択されたルート番号に設定
-      me.inputFieldID = id;
+      me.focusedElementID = id;
     });
   }
 
@@ -536,28 +620,11 @@ class AutocompleteDirectionsHandler {
   polyLineListenerCallback(idx, me) {
     return function () {
       me.directionsRenderer.setRouteIndex(idx);
-      for (var j = 0; j < me.poly.length; j++) {
-        if (j == idx) {
-          me.poly[j].setOptions({
-            //選択したルートの場合、色をcolorCodeに従って変更
-            clickable: true,
-            strokeColor: me.colorCode,
-            strokeOpacity: 1.0,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを他のルートより大きくする。
-            zIndex: parseInt(me.routeNum) + 1,
-          });
+      for (let j = 0; j < me.poly.length; j++) {
+        if (j === idx) {
+          me.poly[j].setOptions(optionsForSelected(me.colorCode, me.routeNum));
         } else {
-          me.poly[j].setOptions({
-            //選択したルート以外の場合、色を#808080に設定(選択されている場合、色付きだから、
-            //元に戻すためには、全てのルートについて#808080に設定する必要あり。
-            clickable: true,
-            strokeColor: "#808080",
-            strokeOpacity: 0.7,
-            strokeWeight: 7,
-            //色付きラインを一番上に表示するため、zIndexを小さくする
-            zIndex: parseInt(me.routeNum),
-          });
+          me.poly[j].setOptions(optionsForAlternatives(me.routeNum));
         }
         me.poly[j].setMap(me.map);
       }
@@ -578,15 +645,9 @@ class AutocompleteDirectionsHandler {
       provideRouteAlternatives: true,
     };
     //公共交通機関を選択した場合
-    if (document.getElementById("changemode-transit" + this.routeNum).checked) {
-      if (
-        document
-          .getElementById("origin-input" + me.routeNum)
-          .value.indexOf("日本") !== -1
-      ) {
-        window.alert(
-          "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-        );
+    if (this.elements.modeTransit.checked) {
+      if (me.elements.originInput.value.indexOf("日本") !== -1) {
+        window.alert(MSG_CANNOT_USE_IN_JAPAN);
         return;
       }
       this.directionsRequest.transitOptions = {};
@@ -596,9 +657,9 @@ class AutocompleteDirectionsHandler {
       );
 
       //「すぐに出発」以外のボタンが押されている場合
-      if (!document.getElementById("depart-now" + me.routeNum).checked) {
+      if (!me.elements.departNow.checked) {
         //ブラウザのタイムゾーンでの指定時間
-        var specTime = new Date(
+        let specTime = new Date(
           document.getElementById("date" + this.routeNum).value +
             "T" +
             document.getElementById("time" + this.routeNum).value
@@ -615,31 +676,26 @@ class AutocompleteDirectionsHandler {
         );
 
         //出発時間を指定した場合
-        if (document.getElementById("depart-time" + me.routeNum).checked) {
+        if (me.elements.specifyDeparture.checked) {
           me.directionsRequest.transitOptions.departureTime = specTime;
         }
         //到着時間を指定した場合
-        else if (
-          document.getElementById("arrival-time" + me.routeNum).checked
-        ) {
+        else if (me.elements.specifyArrival.checked) {
           me.directionsRequest.transitOptions.arrivalTime = specTime;
         }
       }
-
       //乗り換え回数が最小になるようセット
-      this.directionsRequest.transitOptions.routingPreference =
-        "FEWER_TRANSFERS";
+      me.directionsRequest.transitOptions.routingPreference = "FEWER_TRANSFERS";
     }
+
     //自動車ルートを指定した場合
-    else if (
-      document.getElementById("changemode-driving" + this.routeNum).checked
-    ) {
+    else if (this.elements.modeDriving.checked) {
       //有料道路不使用の場合
-      if (document.getElementById("avoid-toll" + this.routeNum).checked) {
+      if (me.elements.avoidToll.checked) {
         this.directionsRequest.avoidTolls = true;
       }
       //高速道路不使用の場合
-      if (document.getElementById("avoid-highway" + this.routeNum).checked) {
+      if (me.elements.avoidHighway.checked) {
         this.directionsRequest.avoidHighways = true;
       }
     }
@@ -649,48 +705,34 @@ class AutocompleteDirectionsHandler {
       if (status === "OK") {
         //検索結果表示前に、現在の表示を全て削除
         if (me.poly.length > 0) {
-          for (var i = 0; i < me.poly.length; i++) {
+          for (let i = 0; i < me.poly.length; i++) {
             me.poly[i].setMap(null);
           }
           me.poly = [];
         }
-
         if (
-          response.request.travelMode == "TRANSIT" &&
+          response.request.travelMode === "TRANSIT" &&
           response.routes[0].legs[0].start_address.match(/日本/)
         ) {
-          document.getElementById("route-decide" + me.routeNum).style.display =
-            "none";
-          alert(
-            "日本の公共交通機関情報はGoogleによる機能制限により、ご利用いただけません。海外の公共交通機関情報はご利用いただけます。"
-          );
+          me.elements.routeDecideButton.style.display = "none";
+          alert(MSG_CANNOT_USE_IN_JAPAN);
           return;
         }
         //複数ルートが帰ってきた場合、それぞれについて、ラインを描画する
-        for (var i = 0; i < response.routes.length; i++) {
-          var routePolyline = new google.maps.Polyline();
+        for (let i = 0; i < response.routes.length; i++) {
+          let routePolyline = new google.maps.Polyline();
           routePolyline.setPath(response.routes[i].overview_path);
 
           //
-          routePolyline.setOptions({
-            clickable: true,
-            strokeColor: "#808080", //線の色
-            strokeOpacity: 0.5, //線の透明度
-            strokeWeight: 7, //線の太さ
-          });
+          routePolyline.setOptions(optionsForAlternatives(me.routeNum));
           routePolyline.setMap(me.map);
           me.poly.push(routePolyline);
 
-          var callback = me.polyLineListenerCallback(i, me);
+          let callback = me.polyLineListenerCallback(i, me);
           me.poly[i].addListener("click", callback);
         }
         //インデックス番号0のルートに色をつける
-        me.poly[0].setOptions({
-          clickable: true,
-          strokeColor: me.colorCode, //線の色
-          strokeOpacity: 0.5, //線の透明度
-          strokeWeight: 7, //線の太さ
-        });
+        me.poly[0].setOptions(optionsForSelected(me.colorCode,me.routeNum));
         me.directionsRenderer.setRouteIndex(0);
 
         //responseをRendererに渡して、パネルにルートを表示
@@ -724,8 +766,7 @@ class AutocompleteDirectionsHandler {
           ).style.display = "none";
         }
       } else {
-        document.getElementById("route-decide" + me.routeNum).style.display =
-          "none";
+        me.elements.routeDecideButton.style.display = "none";
         window.alert(
           "ルートが見つかりませんでした。出発地と目的地の距離が遠すぎる場合、結果が表示されない場合があります。"
         );
@@ -735,7 +776,7 @@ class AutocompleteDirectionsHandler {
 }
 
 function genSearchBox(routeId, color) {
-  var route_html_tpl = `<h2 class="toggle-title pl-3 pt-3 mb-0" id="toggle-${routeId}" style="background-color: ${color}">ルート${
+  const route_html_tpl = `<h2 class="toggle-title pl-3 pt-3 mb-0" id="toggle-${routeId}" style="background-color: ${color}">ルート${
     routeId + 1
   }</h2>
         <div class="search-fields">

--- a/app/templates/multi_search/show_and_edit/multi_route_show.js
+++ b/app/templates/multi_search/show_and_edit/multi_route_show.js
@@ -337,10 +337,9 @@ class AutocompleteDirectionsHandler {
     );
     //保存されているルートのみ色付きラインを描画
     if (parseInt(routeNum) < Object.keys(routeInfo.routes).length) {
-      console.log(this.colorCode);
-      this.directionsRenderer.setOptions(
-        optionsForSelected(this.colorCode, this.routeNum)
-      );
+      this.directionsRenderer.setOptions({
+        polylineOptions: optionsForSelected(this.colorCode, this.routeNum),
+      });
       this.directionsRenderer.setDirections(routeInfo.routes[routeNum]);
       document.getElementById("one-result-panel" + routeNum).style.display =
         "block";
@@ -732,7 +731,7 @@ class AutocompleteDirectionsHandler {
           me.poly[i].addListener("click", callback);
         }
         //インデックス番号0のルートに色をつける
-        me.poly[0].setOptions(optionsForSelected(me.colorCode,me.routeNum));
+        me.poly[0].setOptions(optionsForSelected(me.colorCode, me.routeNum));
         me.directionsRenderer.setRouteIndex(0);
 
         //responseをRendererに渡して、パネルにルートを表示


### PR DESCRIPTION
1: document.getElementByIdでDOM要素を取得しているとコードが長くなって読みにくいので、Elementsクラスを作成しDOM要素を参照するよう変更
2: 地図クリック機能を追加した際、infowindow.close()の部分でDOM要素を削除してしまい、ルート２以降のルートでプロパティにアクセスできずバグが発生していた。infowindowをAutocompleteDirectionsHandlerごとにインスタンス化して使用するのでなく、ページ読み込み時に１回だけインスタンス化し各AutocompleteDirectionsHandlerから参照するようにすることでバグが修正できた。また、Autocompleteによる入力と地図クリックからの入力を１つの関数で処理するのではなく、getPlaceInfoとgetPlaceInfoForClickメソッドにそれぞれ分けた。
3: ルート描画のオプションは毎回書いているとコードが長くなるため、関数を呼び出してオブジェクトを返し設定するよう変更
4: varで宣言していた変数をletとconstに置き換えた